### PR TITLE
Debug - Player animation during screen scroll

### DIFF
--- a/code/level.py
+++ b/code/level.py
@@ -617,17 +617,17 @@ class Level:
             case 'Warp_U':
                 self.display_surface.blit(self.transition_surface, (0, hud_offset - self.floor_rect.height + y_offset))
                 self.draw_hud()
-                self.player.offset_position(0, y_fixed_offset)
+                self.player.define_warping_position(0, y_offset)
             case 'Warp_R':
                 self.display_surface.blit(self.transition_surface, (-x_offset, hud_offset))
-                self.player.offset_position(-x_fixed_offset, 0)
+                self.player.define_warping_position(-x_offset, 0)
             case 'Warp_D':
                 self.display_surface.blit(self.transition_surface, (0, hud_offset - y_offset))
                 self.draw_hud()
-                self.player.offset_position(0, -y_fixed_offset)
+                self.player.define_warping_position(0, -y_offset)
             case 'Warp_L':
                 self.display_surface.blit(self.transition_surface, (x_offset - self.floor_rect.width, hud_offset))
-                self.player.offset_position(x_fixed_offset, 0)
+                self.player.define_warping_position(x_offset, 0)
 
     def death(self):
         self.draw_hud()
@@ -898,6 +898,7 @@ class Level:
                     self.draw_floor()
                     self.create_map(self.current_map + str(self.current_map_screen))
                     self.player.set_state('idle')
+                    self.player.set_position((self.player.warping_x, self.player.warping_y))
                     self.map_scroll_animation_counter = 0
                     self.in_map_transition = None
             # Other transitions (caves with stairs animation, or secret stairs with no animation

--- a/code/player.py
+++ b/code/player.py
@@ -93,6 +93,8 @@ class Player(Entity):
         self.speed = 3
 
         self.pos = pos
+        self.warping_x = 0
+        self.warping_y = 0
         self.image = self.walking_animations[self.direction_label][0]
         self.rect = self.image.get_rect(topleft=pos)
         self.hitbox = self.rect.inflate(-8, -16)
@@ -648,9 +650,9 @@ class Player(Entity):
         if self.has_item(label):
             self.itemB = label
 
-    def offset_position(self, offset_x, offset_y):
-        new_x = self.hitbox.x + offset_x
-        new_y = self.hitbox.y + offset_y
+    def define_warping_position(self, offset_x, offset_y):
+        new_x = self.rect.x + offset_x
+        new_y = self.rect.y + offset_y
 
         if TILE_SIZE >= new_x:
             new_x = TILE_SIZE + 1
@@ -662,18 +664,17 @@ class Player(Entity):
         elif new_y >= SCREEN_HEIGHT - TILE_SIZE * 3:
             new_y = SCREEN_HEIGHT - TILE_SIZE * 3 - 1
 
-        self.hitbox.x = new_x
-        self.hitbox.y = new_y
-        self.rect.top = self.hitbox.top - 12
-        self.rect.left = self.hitbox.left - 4
+        self.warping_x = new_x
+        self.warping_y = new_y
 
     def set_position(self, pos):
-        self.hitbox.x = pos[0]
-        self.hitbox.y = pos[1]
-        self.rect.top = self.hitbox.top - 12
-        self.rect.left = self.hitbox.left - 4
+        self.rect.x = pos[0]
+        self.rect.y = pos[1]
+        self.hitbox.top = self.rect.top + 12
+        self.hitbox.left = self.rect.left + 4
 
     def update(self):
+        player_draw_pos = self.rect.topleft
         if not self.isDead:
             if 'hurt' not in self.state:
                 self.input()
@@ -683,6 +684,8 @@ class Player(Entity):
 
             if self.state != 'warping':
                 self.move()
+            else:
+                player_draw_pos = (self.warping_x, self.warping_y)
             self.animate()
             self.cooldowns()
             if self.health <= 0:
@@ -691,4 +694,4 @@ class Player(Entity):
         else:
             self.animate()
 
-        pygame.display.get_surface().blit(self.image, self.rect.topleft)
+        pygame.display.get_surface().blit(self.image, player_draw_pos)


### PR DESCRIPTION
Player used to not scroll as the same speed as the level when warping to another screen. 

Now it's way better.