### PR TITLE
Fix - Monster can hurt player if collision during despawn animation

### DIFF
--- a/code/enemies.py
+++ b/code/enemies.py
@@ -117,6 +117,7 @@ class Enemy(Entity):
         elif not self.isDead:
             super().animate()
         else:
+            self.hitbox = self.rect.inflate(-32, -32)
             self.despawn_animation_starting_time, self.despawn_animation_frame_count = (
                 self.change_animation_frame(self.despawn_animation,
                                             self.despawn_animation_frame_count,


### PR DESCRIPTION
Dead monsters could still hurt the Player. 
Bug that slipped through the animate() refacto for Entity-Enemy : forgot to re-add the shrink of the hitbox for Enemy in its own animate()