### PR TITLE
Fix - Bomb secrets

### DIFF
--- a/code/particles.py
+++ b/code/particles.py
@@ -640,11 +640,6 @@ class Bomb(Particle):
         self.nb_frames = PBOMB_FRAMES
         self.load_animation_frames(particle_tileset)
 
-        self.image = self.move_animations[0]
-        self.rect = self.image.get_rect(topleft=(self.pos_x, self.pos_y))
-        self.hitbox = self.rect.inflate(32, 32)
-        self.hitbox.center = self.rect.center
-
         self.collision_damage = 0
 
         self.bomb_drop_sound = pygame.mixer.Sound(SOUND_BOMB_DROP)
@@ -652,11 +647,6 @@ class Bomb(Particle):
         self.bomb_drop_sound.play()
         self.bomb_explode_sound = pygame.mixer.Sound(SOUND_BOMB_EXPLODE)
         self.bomb_explode_sound.set_volume(0.3)
-
-        self.is_active = True
-
-        self.ignited_starting_time = pygame.time.get_ticks()
-        self.explosion_cooldown = 1000
 
         match owner_direction_label:
             case 'up':
@@ -671,7 +661,14 @@ class Bomb(Particle):
             case 'left':
                 self.pos_x = owner_pos[0] - 24
                 self.pos_y = owner_pos[1]
-        self.rect.topleft = (self.pos_x, self.pos_y)
+        self.image = self.move_animations[0]
+        self.rect = self.image.get_rect(topleft=(self.pos_x, self.pos_y))
+        self.hitbox = self.rect.inflate(24, 32)
+
+        self.is_active = True
+
+        self.ignited_starting_time = pygame.time.get_ticks()
+        self.explosion_cooldown = 1000
 
     def load_animation_frames(self, particle_tileset):
         super().load_animation_frames(particle_tileset)
@@ -681,7 +678,7 @@ class Bomb(Particle):
 
     def collision(self, direction):
         for secret_passage in self.secret_bomb_sprites:
-            if (secret_passage.rect.colliderect(self.hitbox)
+            if (secret_passage.hitbox.colliderect(self.hitbox)
                     and not secret_passage.is_revealed):
                 secret_passage.reveal()
 
@@ -705,7 +702,7 @@ class Bomb(Particle):
             self.effect()
             self.kill()
         else:
-            super().update()
+            pygame.display.get_surface().blit(self.image, self.rect.topleft)
 
 
 class BombSmoke(Particle):

--- a/code/warp.py
+++ b/code/warp.py
@@ -30,14 +30,13 @@ class SecretPassage(Warp):
         super().__init__(pos, groups, warp_id, player, level)
 
         self.obstacle_sprites = obstacle_sprites
+        self.warp_id = warp_id
         self.level_id = level_id
         self.is_revealed = is_revealed
 
         self.image = surface
-        self.rect = self.image.get_rect(topleft=pos)
-        self.hitbox = self.rect.inflate(-16, -16)
-        if UNDERWORLD_STAIRS[int(warp_id) - 4]['stairs']:
-            self.hitbox.top = self.rect.top
+        self.rect = self.image.get_rect(topleft=(self.pos_x, self.pos_y))
+        self.hitbox = self.rect
 
         # Ensure Obstacle destruction if secret is already revealed
         if self.is_revealed:
@@ -49,6 +48,9 @@ class SecretPassage(Warp):
     def reveal(self):
         self.is_revealed = True
         MAP_SECRETS_REVEALED[self.level_id] = True
+        self.hitbox = self.rect.inflate(-16, -16)
+        if UNDERWORLD_STAIRS[int(self.warp_id) - 4]['stairs']:
+            self.hitbox.top = self.rect.top
         for obstacle in self.obstacle_sprites:
             if obstacle.rect.colliderect(self.rect):
                 obstacle.kill()
@@ -56,4 +58,4 @@ class SecretPassage(Warp):
     def update(self):
         if self.is_revealed:
             self.collisions()
-            pygame.display.get_surface().blit(self.image, (self.pos_x, self.pos_y))
+            pygame.display.get_surface().blit(self.image, self.rect.topleft)


### PR DESCRIPTION
Bomb secrets were revealed when touched by Bomb directly, not when Bomb is exploding : this is caused by calling super().update() which by default calls for collision('') before we want it. 

Bomb explosion hitbox was not centered where it should have been, as rect moved depending on the direction the player was facing, and hitbox was defined before this alteration of position. 

Warp hitbox encompasses the whole rect size (2*TILE_SIZE, 2*TILE_SIZE) when not destroyed, and when revealed is shrunk to the proper size in order to have the player animate at the proper position 

Explosion hitbox has been modified to better fit visually with the smoke effects and general feel.