### PR TITLE
Fix - Player action during warp/stairs animation

### DIFF
--- a/code/player.py
+++ b/code/player.py
@@ -228,7 +228,7 @@ class Player(Entity):
         return False
 
     def can_action(self):
-        if 'action' not in self.state:
+        if 'action' not in self.state and self.state != 'warping' and self.state != 'stairs':
             return True
         return False
 


### PR DESCRIPTION
Player was able to use its actionA or actionB during stairs animation and screen transition scrolling animation.

For the scrolling, it would interrupt the walking animation and the player could walk everywhere (no border/obstacle yet instantiated), and would be teleported back to the correct position at the end of the animation.
Player could lose his boomerang sprite this way, with infinite sound and no possibility of throwing it again until next screen transition.