### PR TITLE
Feature - Save / Load

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ Game can be closed by pressing ```ESC``` on the GAME OVER screen, or  ```ANY KEY
 
 Game can be continued by pressing ```RETURN``` on the GAME OVER screen
 
+Game state can be saved by pressing ```F5``` when appropriate
+
+Game state can be loaded from saved state by pressing ```F6``` when appropriate. This will reset the Player's position to where the game starts
+
 ## Gameplay hints
 
-You can't block non magic projectiles with your shield
+You can't block non-magic projectiles with your shield
 
 You can torch some trees with the candle, and reveal hidden caves
 
@@ -123,4 +127,4 @@ And thanks to the people who will stumble upon this and read it !
 
 This project could definitely be coded in a cleaner manner, and the more projects I'll work on, the better my code will get.
 
-This one is a first stone, and will stay the way it is so I can come back to it, and see my progress. I hope that I will see progress.
+This one is a first stone, and will stay the way it is, so I can come back to it and see my progress. I hope that I will see progress.

--- a/code/door.py
+++ b/code/door.py
@@ -1,53 +1,53 @@
 import pygame
 import tileset
 import level as game
-from settings import *
+import settings as cfg
 
 
 class Door(pygame.sprite.Sprite):
-    def __init__(self, groups, door_position, door_type=DOOR_KEY_LABEL):
+    def __init__(self, groups, door_position, door_type=cfg.DOOR_KEY_LABEL):
         super().__init__()
         for group in groups:
             self.add(group)
 
         self.door_position = door_position
         self.type = door_type
-        if door_position == UP_LABEL:
-            self.image_position = DOOR_UP_POS
-            if door_type == DOOR_KEY_LABEL:
-                self.sprite_id = DOOR_KEY_UP_FRAME_ID
+        if door_position == cfg.UP_LABEL:
+            self.image_position = cfg.DOOR_UP_POS
+            if door_type == cfg.DOOR_KEY_LABEL:
+                self.sprite_id = cfg.DOOR_KEY_UP_FRAME_ID
             else:
-                self.sprite_id = DOOR_EVENT_UP_FRAME_ID
-        elif door_position == RIGHT_LABEL:
-            self.image_position = DOOR_RIGHT_POS
-            if door_type == DOOR_KEY_LABEL:
-                self.sprite_id = DOOR_KEY_RIGHT_FRAME_ID
+                self.sprite_id = cfg.DOOR_EVENT_UP_FRAME_ID
+        elif door_position == cfg.RIGHT_LABEL:
+            self.image_position = cfg.DOOR_RIGHT_POS
+            if door_type == cfg.DOOR_KEY_LABEL:
+                self.sprite_id = cfg.DOOR_KEY_RIGHT_FRAME_ID
             else:
-                self.sprite_id = DOOR_EVENT_RIGHT_FRAME_ID
-        elif door_position == DOWN_LABEL:
-            self.image_position = DOOR_DOWN_POS
-            if door_type == DOOR_KEY_LABEL:
-                self.sprite_id = DOOR_KEY_DOWN_FRAME_ID
+                self.sprite_id = cfg.DOOR_EVENT_RIGHT_FRAME_ID
+        elif door_position == cfg.DOWN_LABEL:
+            self.image_position = cfg.DOOR_DOWN_POS
+            if door_type == cfg.DOOR_KEY_LABEL:
+                self.sprite_id = cfg.DOOR_KEY_DOWN_FRAME_ID
             else:
-                self.sprite_id = DOOR_EVENT_DOWN_FRAME_ID
+                self.sprite_id = cfg.DOOR_EVENT_DOWN_FRAME_ID
         else:
-            self.image_position = DOOR_LEFT_POS
-            if door_type == DOOR_KEY_LABEL:
-                self.sprite_id = DOOR_KEY_LEFT_FRAME_ID
+            self.image_position = cfg.DOOR_LEFT_POS
+            if door_type == cfg.DOOR_KEY_LABEL:
+                self.sprite_id = cfg.DOOR_KEY_LEFT_FRAME_ID
             else:
-                self.sprite_id = DOOR_EVENT_LEFT_FRAME_ID
+                self.sprite_id = cfg.DOOR_EVENT_LEFT_FRAME_ID
         self.image = tileset.DOORS_TILE_SET.get_sprite_image(self.sprite_id)
         self.rect = self.image.get_rect(topleft=self.image_position)
         self.hitbox = self.rect.inflate(-4, -4)
-        self.door_sound = pygame.mixer.Sound(SOUND_DOOR)
+        self.door_sound = pygame.mixer.Sound(cfg.SOUND_DOOR)
         self.door_sound.set_volume(0.3)
         self.door_sound.play()
 
     def open(self):
         level_id = str(game.Level().current_map) + str(game.Level().current_map_screen)
-        DUNGEON_DOORS[level_id].pop(self.door_position)
-        if self.type == DOOR_EVENT_LABEL:
-            MONSTER_KILL_EVENT.pop(level_id)
+        cfg.DUNGEON_DOORS[level_id].pop(self.door_position)
+        if self.type == cfg.DOOR_EVENT_LABEL:
+            cfg.MONSTER_KILL_EVENT.pop(level_id)
         self.door_sound.play()
         self.kill()
 

--- a/code/inputs.py
+++ b/code/inputs.py
@@ -15,6 +15,8 @@ MENU_KEY = pygame.K_ESCAPE
 SUICIDE_KEY = pygame.K_BACKSPACE
 CONTINUE_KEY = pygame.K_RETURN
 EXIT_KEY = pygame.K_ESCAPE
+SAVE_KEY = pygame.K_F5
+LOAD_KEY = pygame.K_F6
 
 
 def is_move_key_pressed(keys):

--- a/code/level.py
+++ b/code/level.py
@@ -1329,3 +1329,24 @@ class Level(metaclass=Singleton):
             # Only visible sprites left at this point are the Player, and all the HUD sprites
 
             self.visible_sprites.update()
+
+    def save(self):
+        f = open("../save/save", "w")
+        save_content = (f'current_max_health:{self.player.current_max_health}\n'
+                        + f'health:{self.player.health}\n'
+                        + f'bombs:{self.player.bombs}\n'
+                        + f'keys:{self.player.keys}\n'
+                        + f'money:{self.player.money}\n'
+                        + f'has_boomerang:{self.player.has_boomerang}\n'
+                        + f'has_bombs:{self.player.has_bombs}\n'
+                        + f'has_candle:{self.player.has_candle}\n'
+                        + f'has_ladder:{self.player.has_ladder}\n'
+                        + f'has_wood_sword:{self.player.has_wood_sword}\n'
+                        + f'MAP_SECRETS_REVEALED:{MAP_SECRETS_REVEALED}\n'
+                        + f'MAP_ITEMS:{MAP_ITEMS}\n'
+                        + f'SHOPS:{SHOPS}\n'
+                        + f'MONSTER_KILL_EVENT:{MONSTER_KILL_EVENT}\n'
+                        + f'DUNGEON_DECIMATION:{DUNGEON_DECIMATION}\n'
+                        + f'DUNGEON_DOORS:{DUNGEON_DOORS}\n')
+        f.write(save_content)
+        f.close()

--- a/code/level.py
+++ b/code/level.py
@@ -43,6 +43,9 @@ class Level(metaclass=Singleton):
         self.transition_surface = None
         self.menu_surface = None
         self.menu_rect = None
+        self.sys_text_surface = None
+        self.sys_text_starting_time = 0
+        self.sys_text_cooldown = 2500
 
         # Set up group sprites
         self.warp_sprites = pygame.sprite.Group()
@@ -1330,23 +1333,43 @@ class Level(metaclass=Singleton):
 
             self.visible_sprites.update()
 
+        if self.sys_text_surface is not None:
+            sys_text_rect = self.sys_text_surface.get_rect()
+            x = (SCREEN_WIDTH - sys_text_rect.width) // 2
+            y = HUD_OFFSET + TILE_SIZE
+            sys_text_rect.topleft = (x, y)
+            pygame.draw.rect(self.display_surface, 'black', sys_text_rect)
+            self.display_surface.blit(self.sys_text_surface, sys_text_rect)
+            if pygame.time.get_ticks() - self.sys_text_starting_time >= self.sys_text_cooldown:
+                self.sys_text_surface = None
+
     def save(self):
-        f = open("../save/save", "w")
-        save_content = (f'current_max_health:{self.player.current_max_health}\n'
-                        + f'health:{self.player.health}\n'
-                        + f'bombs:{self.player.bombs}\n'
-                        + f'keys:{self.player.keys}\n'
-                        + f'money:{self.player.money}\n'
-                        + f'has_boomerang:{self.player.has_boomerang}\n'
-                        + f'has_bombs:{self.player.has_bombs}\n'
-                        + f'has_candle:{self.player.has_candle}\n'
-                        + f'has_ladder:{self.player.has_ladder}\n'
-                        + f'has_wood_sword:{self.player.has_wood_sword}\n'
-                        + f'MAP_SECRETS_REVEALED:{MAP_SECRETS_REVEALED}\n'
-                        + f'MAP_ITEMS:{MAP_ITEMS}\n'
-                        + f'SHOPS:{SHOPS}\n'
-                        + f'MONSTER_KILL_EVENT:{MONSTER_KILL_EVENT}\n'
-                        + f'DUNGEON_DECIMATION:{DUNGEON_DECIMATION}\n'
-                        + f'DUNGEON_DOORS:{DUNGEON_DOORS}\n')
-        f.write(save_content)
-        f.close()
+        try:
+            f = open("../save/save", "w")
+            save_content = (f'current_max_health:{self.player.current_max_health}\n'
+                            + f'health:{self.player.health}\n'
+                            + f'bombs:{self.player.bombs}\n'
+                            + f'keys:{self.player.keys}\n'
+                            + f'money:{self.player.money}\n'
+                            + f'has_boomerang:{self.player.has_boomerang}\n'
+                            + f'has_bombs:{self.player.has_bombs}\n'
+                            + f'has_candle:{self.player.has_candle}\n'
+                            + f'has_ladder:{self.player.has_ladder}\n'
+                            + f'has_wood_sword:{self.player.has_wood_sword}\n'
+                            + f'MAP_SECRETS_REVEALED:{MAP_SECRETS_REVEALED}\n'
+                            + f'MAP_ITEMS:{MAP_ITEMS}\n'
+                            + f'SHOPS:{SHOPS}\n'
+                            + f'MONSTER_KILL_EVENT:{MONSTER_KILL_EVENT}\n'
+                            + f'DUNGEON_DECIMATION:{DUNGEON_DECIMATION}\n'
+                            + f'DUNGEON_DOORS:{DUNGEON_DOORS}\n')
+            f.write(save_content)
+            f.close()
+            font = pygame.font.Font(None, 30)
+            self.sys_text_surface = font.render(str('Saved successfully'), True, 'white')
+            self.sys_text_starting_time = pygame.time.get_ticks()
+        except OSError as error:
+            font = pygame.font.Font(None, 30)
+            self.sys_text_surface = font.render(str('Save Failed'), True, 'red')
+            self.sys_text_starting_time = pygame.time.get_ticks()
+            message = f"Couldn't save progress. An OSError has occurred. Arguments:\n{error.args}"
+            print(message, file=sys.stderr)

--- a/code/level.py
+++ b/code/level.py
@@ -2,7 +2,6 @@ import random
 
 import pygame.mixer
 
-from settings import *
 from support import *
 from inputs import *
 import tileset
@@ -69,35 +68,35 @@ class Level(metaclass=Singleton):
 
         self.equipped_item_a_sprite = None
         self.equipped_item_b_sprite = None
-        self.current_selected_item = NONE_LABEL
+        self.current_selected_item = cfg.NONE_LABEL
         self.menu_item_coord_and_frame_id = {
-            BOOMERANG_LABEL: (MENU_BOOMERANG_TOPLEFT, BOOMERANG_FRAME_ID),
-            BOMB_LABEL: (MENU_BOMBS_TOPLEFT, BOMB_FRAME_ID),
-            CANDLE_LABEL: (MENU_CANDLE_TOPLEFT, RED_CANDLE_FRAME_ID)
+            cfg.BOOMERANG_LABEL: (cfg.MENU_BOOMERANG_TOPLEFT, cfg.BOOMERANG_FRAME_ID),
+            cfg.BOMB_LABEL: (cfg.MENU_BOMBS_TOPLEFT, cfg.BOMB_FRAME_ID),
+            cfg.CANDLE_LABEL: (cfg.MENU_CANDLE_TOPLEFT, cfg.RED_CANDLE_FRAME_ID)
         }
         self.item_selector = None
         self.item_selected_sprite = None
         self.item_picked_up = None
 
         # Set up sounds
-        self.overworld_background_theme = pygame.mixer.Sound(THEME_OVERWORLD)
+        self.overworld_background_theme = pygame.mixer.Sound(cfg.THEME_OVERWORLD)
         self.overworld_background_theme.set_volume(0.2)
-        self.dungeon_background_theme = pygame.mixer.Sound(THEME_DUNGEON)
+        self.dungeon_background_theme = pygame.mixer.Sound(cfg.THEME_DUNGEON)
         self.dungeon_background_theme.set_volume(0.2)
-        self.game_over_sound = pygame.mixer.Sound(SOUND_GAME_OVER)
+        self.game_over_sound = pygame.mixer.Sound(cfg.SOUND_GAME_OVER)
         self.game_over_sound.set_volume(0.4)
-        self.event_cleared_sound = pygame.mixer.Sound(SOUND_EVENT_CLEARED)
+        self.event_cleared_sound = pygame.mixer.Sound(cfg.SOUND_EVENT_CLEARED)
         self.event_cleared_sound.set_volume(0.4)
-        self.triforce_sound = pygame.mixer.Sound(SOUND_TRIFORCE_OBTAINED)
+        self.triforce_sound = pygame.mixer.Sound(cfg.SOUND_TRIFORCE_OBTAINED)
         self.triforce_sound.set_volume(0.4)
 
-        self.current_map = STARTING_MAP
-        self.current_map_screen = STARTING_SCREEN
-        if self.current_map == OVERWORLD_STARTING_MAP:
-            self.load_player(OVERWORLD_PLAYER_START_POS)
+        self.current_map = cfg.STARTING_MAP
+        self.current_map_screen = cfg.STARTING_SCREEN
+        if self.current_map == cfg.OVERWORLD_STARTING_MAP:
+            self.load_player(cfg.OVERWORLD_PLAYER_START_POS)
             self.overworld_background_theme.play(loops=-1)
         else:
-            self.load_player(DUNGEON_PLAYER_START_POS)
+            self.load_player(cfg.DUNGEON_PLAYER_START_POS)
             self.dungeon_background_theme.play(loops=-1)
         self.create_map(self.current_map + self.current_map_screen)
         self.in_map_transition = None
@@ -110,42 +109,42 @@ class Level(metaclass=Singleton):
         self.dead_monsters_event_played = False
 
         self.key_pressed_start_timer = 0
-        self.key_pressed_cooldown = LEVEL_KEY_PRESSED_COOLDOWN
+        self.key_pressed_cooldown = cfg.LEVEL_KEY_PRESSED_COOLDOWN
 
         # Set Stairs animation timer
         self.stairs_animation_starting_time = 0
-        self.stairs_animation_duration = PLAYER_STAIRS_DURATION
+        self.stairs_animation_duration = cfg.PLAYER_STAIRS_DURATION
         # Set Victory animation variables & timers
         self.victory_played = False
         self.victory_floor_index = 0
         self.victory_motion_index = 0
         self.victory_floor_switch_starting_time = 0
-        self.victory_floor_switch_cooldown = MAP_VICTORY_FADE_COOLDOWN
+        self.victory_floor_switch_cooldown = cfg.MAP_VICTORY_FADE_COOLDOWN
         # Set Game Over animation variables & timers
         self.death_played = False
         self.death_floor_index = 0
         self.death_motion_index = 0
         self.death_spin_starting_time = 0
-        self.death_spin_cooldown = PLAYER_DEATH_SPIN_AMOUNT * PLAYER_DEATH_SPIN_DURATION
-        self.death_floor_switch_cooldown = MAP_DEATH_FADE_COOLDOWN
+        self.death_spin_cooldown = cfg.PLAYER_DEATH_SPIN_AMOUNT * cfg.PLAYER_DEATH_SPIN_DURATION
+        self.death_floor_switch_cooldown = cfg.MAP_DEATH_FADE_COOLDOWN
         self.death_floor_switch_starting_time = 0
-        self.death_gray_cooldown = PLAYER_GRAY_COOLDOWN
+        self.death_gray_cooldown = cfg.PLAYER_GRAY_COOLDOWN
         self.death_gray_starting_time = 0
-        self.death_despawn_cooldown = PLAYER_DEATH_ANIMATION_COOLDOWN * PLAYER_DEATH_FRAMES
+        self.death_despawn_cooldown = cfg.PLAYER_DEATH_ANIMATION_COOLDOWN * cfg.PLAYER_DEATH_FRAMES
         self.death_despawn_starting_time = 0
-        self.death_hurt_cooldown = PLAYER_DEATH_HURT_COOLDOWN
+        self.death_hurt_cooldown = cfg.PLAYER_DEATH_HURT_COOLDOWN
         self.death_hurt_starting_time = 0
 
     def draw_selector(self):
         # creates the item selector for the menu screen
-        selector_pos = MENU_BOOMERANG_TOPLEFT
-        if self.current_selected_item != NONE_LABEL:
+        selector_pos = cfg.MENU_BOOMERANG_TOPLEFT
+        if self.current_selected_item != cfg.NONE_LABEL:
             selector_pos = self.menu_item_coord_and_frame_id[self.current_selected_item][0]
         self.item_selector = Selector((self.menu_sprites,), selector_pos)
 
     def draw_menu(self):
         # Draw background
-        self.floor_surface = pygame.image.load(PAUSE_MENU_PATH).convert()
+        self.floor_surface = pygame.image.load(cfg.PAUSE_MENU_PATH).convert()
         self.floor_rect = self.floor_surface.get_rect(topleft=(0, 0))
         self.display_surface.blit(self.floor_surface, (0, 0))
 
@@ -156,35 +155,35 @@ class Level(metaclass=Singleton):
 
     def draw_items(self):
         # Draw (if any) the currently selected item in the frame left of the items owned
-        if self.current_selected_item != NONE_LABEL:
+        if self.current_selected_item != cfg.NONE_LABEL:
             if self.item_selected_sprite is not None:
                 self.item_selected_sprite.kill()
-            self.item_selected_sprite = Tile(MENU_SELECTED_ITEM_TOPLEFT,
+            self.item_selected_sprite = Tile(cfg.MENU_SELECTED_ITEM_TOPLEFT,
                                              (self.menu_sprites,),
                                              tileset.ITEMS_TILE_SET.get_sprite_image(
                                                  self.menu_item_coord_and_frame_id[self.current_selected_item][1]))
 
         # Passive Items
-        if self.player.has_item(LADDER_LABEL):
-            Tile(MENU_LADDER_TOPLEFT,
+        if self.player.has_item(cfg.LADDER_LABEL):
+            Tile(cfg.MENU_LADDER_TOPLEFT,
                  (self.menu_sprites,),
-                 tileset.ITEMS_TILE_SET.get_sprite_image(LADDER_FRAME_ID))
+                 tileset.ITEMS_TILE_SET.get_sprite_image(cfg.LADDER_FRAME_ID))
 
         # Selectable items
-        if self.player.has_item(BOOMERANG_LABEL):
+        if self.player.has_item(cfg.BOOMERANG_LABEL):
             # Didn't implement red/blue boomerang system
-            Tile(MENU_BOOMERANG_TOPLEFT,
+            Tile(cfg.MENU_BOOMERANG_TOPLEFT,
                  (self.menu_sprites,),
-                 tileset.ITEMS_TILE_SET.get_sprite_image(BOOMERANG_FRAME_ID))
-        if self.player.has_item(BOMB_LABEL):
-            Tile(MENU_BOMBS_TOPLEFT,
+                 tileset.ITEMS_TILE_SET.get_sprite_image(cfg.BOOMERANG_FRAME_ID))
+        if self.player.has_item(cfg.BOMB_LABEL):
+            Tile(cfg.MENU_BOMBS_TOPLEFT,
                  (self.menu_sprites,),
-                 tileset.ITEMS_TILE_SET.get_sprite_image(BOMB_FRAME_ID))
-        if self.player.has_item(CANDLE_LABEL):
+                 tileset.ITEMS_TILE_SET.get_sprite_image(cfg.BOMB_FRAME_ID))
+        if self.player.has_item(cfg.CANDLE_LABEL):
             # Didn't implement red/blue candle system
-            Tile(MENU_CANDLE_TOPLEFT,
+            Tile(cfg.MENU_CANDLE_TOPLEFT,
                  (self.menu_sprites,),
-                 tileset.ITEMS_TILE_SET.get_sprite_image(RED_CANDLE_FRAME_ID))
+                 tileset.ITEMS_TILE_SET.get_sprite_image(cfg.RED_CANDLE_FRAME_ID))
 
     def draw_triforce(self):
         # TriForce fragment system is not implemented yet
@@ -193,9 +192,9 @@ class Level(metaclass=Singleton):
 
     def draw_hud(self):
         # Draw HUD space either at the top (level) or the bottom (pause menu) of the screen
-        self.menu_surface = pygame.image.load(HUD_PERMA_PATH).convert()
+        self.menu_surface = pygame.image.load(cfg.HUD_PERMA_PATH).convert()
         if self.in_menu:
-            top_left = (0, SCREEN_HEIGHT - HUD_OFFSET)
+            top_left = (0, cfg.SCREEN_HEIGHT - cfg.HUD_OFFSET)
         else:
             top_left = (0, 0)
         self.menu_rect = self.menu_surface.get_rect(topleft=top_left)
@@ -222,12 +221,12 @@ class Level(metaclass=Singleton):
         hundreds = self.player.money // 100
         tens = (self.player.money // 10) % 10
         units = self.player.money % 10
-        hundreds_pos = (self.menu_rect.x + HUD_MONEY_HUNDREDS_POSITION[0],
-                        self.menu_rect.y + HUD_MONEY_HUNDREDS_POSITION[1])
-        tens_pos = (self.menu_rect.x + HUD_MONEY_TENS_POSITION[0],
-                    self.menu_rect.y + HUD_MONEY_TENS_POSITION[1])
-        units_pos = (self.menu_rect.x + HUD_MONEY_UNITS_POSITION[0],
-                     self.menu_rect.y + HUD_MONEY_UNITS_POSITION[1])
+        hundreds_pos = (self.menu_rect.x + cfg.HUD_MONEY_HUNDREDS_POSITION[0],
+                        self.menu_rect.y + cfg.HUD_MONEY_HUNDREDS_POSITION[1])
+        tens_pos = (self.menu_rect.x + cfg.HUD_MONEY_TENS_POSITION[0],
+                    self.menu_rect.y + cfg.HUD_MONEY_TENS_POSITION[1])
+        units_pos = (self.menu_rect.x + cfg.HUD_MONEY_UNITS_POSITION[0],
+                     self.menu_rect.y + cfg.HUD_MONEY_UNITS_POSITION[1])
 
         Tile(hundreds_pos,
              sprite_groups,
@@ -252,12 +251,12 @@ class Level(metaclass=Singleton):
         hundreds = self.player.keys // 100
         tens = (self.player.keys // 10) % 10
         units = self.player.keys % 10
-        hundreds_pos = (self.menu_rect.x + HUD_KEYS_HUNDREDS_POSITION[0],
-                        self.menu_rect.y + HUD_KEYS_HUNDREDS_POSITION[1])
-        tens_pos = (self.menu_rect.x + HUD_KEYS_TENS_POSITION[0],
-                    self.menu_rect.y + HUD_KEYS_TENS_POSITION[1])
-        units_pos = (self.menu_rect.x + HUD_KEYS_UNITS_POSITION[0],
-                     self.menu_rect.y + HUD_KEYS_UNITS_POSITION[1])
+        hundreds_pos = (self.menu_rect.x + cfg.HUD_KEYS_HUNDREDS_POSITION[0],
+                        self.menu_rect.y + cfg.HUD_KEYS_HUNDREDS_POSITION[1])
+        tens_pos = (self.menu_rect.x + cfg.HUD_KEYS_TENS_POSITION[0],
+                    self.menu_rect.y + cfg.HUD_KEYS_TENS_POSITION[1])
+        units_pos = (self.menu_rect.x + cfg.HUD_KEYS_UNITS_POSITION[0],
+                     self.menu_rect.y + cfg.HUD_KEYS_UNITS_POSITION[1])
 
         Tile(hundreds_pos,
              sprite_groups,
@@ -282,12 +281,12 @@ class Level(metaclass=Singleton):
         hundreds = self.player.bombs // 100
         tens = (self.player.bombs // 10) % 10
         units = self.player.bombs % 10
-        hundreds_pos = (self.menu_rect.x + HUD_BOMBS_HUNDREDS_POSITION[0],
-                        self.menu_rect.y + HUD_BOMBS_HUNDREDS_POSITION[1])
-        tens_pos = (self.menu_rect.x + HUD_BOMBS_TENS_POSITION[0],
-                    self.menu_rect.y + HUD_BOMBS_TENS_POSITION[1])
-        units_pos = (self.menu_rect.x + HUD_BOMBS_UNITS_POSITION[0],
-                     self.menu_rect.y + HUD_BOMBS_UNITS_POSITION[1])
+        hundreds_pos = (self.menu_rect.x + cfg.HUD_BOMBS_HUNDREDS_POSITION[0],
+                        self.menu_rect.y + cfg.HUD_BOMBS_HUNDREDS_POSITION[1])
+        tens_pos = (self.menu_rect.x + cfg.HUD_BOMBS_TENS_POSITION[0],
+                    self.menu_rect.y + cfg.HUD_BOMBS_TENS_POSITION[1])
+        units_pos = (self.menu_rect.x + cfg.HUD_BOMBS_UNITS_POSITION[0],
+                     self.menu_rect.y + cfg.HUD_BOMBS_UNITS_POSITION[1])
 
         Tile(hundreds_pos,
              sprite_groups,
@@ -308,36 +307,40 @@ class Level(metaclass=Singleton):
         if self.health_sprites:
             for sprite in self.health_sprites:
                 sprite.kill()
-        nb_hearts = self.player.health // PLAYER_HEALTH_PER_HEART
+        nb_hearts = self.player.health // cfg.PLAYER_HEALTH_PER_HEART
         for heart_i in range(0, nb_hearts):
-            heart_x = self.menu_rect.x + HUD_FIRST_HEART_POSITION_X + (heart_i % 8) * TILE_SIZE
-            heart_y = self.menu_rect.y + HUD_FIRST_HEART_POSITION_Y - (heart_i // HUD_NB_HEARTS_PER_LINE) * TILE_SIZE
+            heart_x = self.menu_rect.x + cfg.HUD_FIRST_HEART_POSITION_X + (heart_i % 8) * cfg.TILE_SIZE
+            heart_y = (self.menu_rect.y + cfg.HUD_FIRST_HEART_POSITION_Y
+                       - (heart_i // cfg.HUD_NB_HEARTS_PER_LINE) * cfg.TILE_SIZE)
             Tile((heart_x, heart_y),
                  sprite_groups,
-                 tileset.HUD_TILE_SET.get_sprite_image(HUD_FULL_HEART_FRAME_ID))
-        if self.player.health % PLAYER_HEALTH_PER_HEART > 0:
-            heart_x = self.menu_rect.x + HUD_FIRST_HEART_POSITION_X + (nb_hearts % 8) * TILE_SIZE
-            heart_y = self.menu_rect.y + HUD_FIRST_HEART_POSITION_Y - (nb_hearts // HUD_NB_HEARTS_PER_LINE) * TILE_SIZE
+                 tileset.HUD_TILE_SET.get_sprite_image(cfg.HUD_FULL_HEART_FRAME_ID))
+        if self.player.health % cfg.PLAYER_HEALTH_PER_HEART > 0:
+            heart_x = self.menu_rect.x + cfg.HUD_FIRST_HEART_POSITION_X + (nb_hearts % 8) * cfg.TILE_SIZE
+            heart_y = (self.menu_rect.y + cfg.HUD_FIRST_HEART_POSITION_Y
+                       - (nb_hearts // cfg.HUD_NB_HEARTS_PER_LINE) * cfg.TILE_SIZE)
             Tile((heart_x, heart_y),
                  sprite_groups,
-                 tileset.HUD_TILE_SET.get_sprite_image(HUD_HALF_HEART_FRAME_ID))
+                 tileset.HUD_TILE_SET.get_sprite_image(cfg.HUD_HALF_HEART_FRAME_ID))
             nb_hearts += 1
-        for heart_i in range(nb_hearts, self.player.current_max_health // PLAYER_HEALTH_PER_HEART):
-            heart_x = self.menu_rect.x + HUD_FIRST_HEART_POSITION_X + (heart_i % 8) * TILE_SIZE
-            heart_y = self.menu_rect.y + HUD_FIRST_HEART_POSITION_Y - (heart_i // HUD_NB_HEARTS_PER_LINE) * TILE_SIZE
+        for heart_i in range(nb_hearts, self.player.current_max_health // cfg.PLAYER_HEALTH_PER_HEART):
+            heart_x = self.menu_rect.x + cfg.HUD_FIRST_HEART_POSITION_X + (heart_i % 8) * cfg.TILE_SIZE
+            heart_y = (self.menu_rect.y + cfg.HUD_FIRST_HEART_POSITION_Y
+                       - (heart_i // cfg.HUD_NB_HEARTS_PER_LINE) * cfg.TILE_SIZE)
             Tile((heart_x, heart_y),
                  sprite_groups,
-                 tileset.HUD_TILE_SET.get_sprite_image(HUD_EMPTY_HEART_FRAME_ID))
+                 tileset.HUD_TILE_SET.get_sprite_image(cfg.HUD_EMPTY_HEART_FRAME_ID))
 
     def draw_floor(self, death_color=''):
         # Draw the background of the level
-        if death_color == BLACK_LABEL:
-            self.floor_surface = pygame.image.load(BLACK_PATH).convert()
+        if death_color == cfg.BLACK_LABEL:
+            self.floor_surface = pygame.image.load(cfg.BLACK_PATH).convert()
         else:
             self.floor_surface = pygame.image.load(
-                f'{LEVELS_PATH}{self.current_map}{self.current_map_screen}{death_color}{GRAPHICS_EXTENSION}').convert()
+                f'{cfg.LEVELS_PATH}{self.current_map}{self.current_map_screen}{death_color}{cfg.GRAPHICS_EXTENSION}'
+            ).convert()
         self.floor_rect = self.floor_surface.get_rect(topleft=(0, 0))
-        self.display_surface.blit(self.floor_surface, (0, HUD_OFFSET))
+        self.display_surface.blit(self.floor_surface, (0, cfg.HUD_OFFSET))
 
     def draw_item_a(self):
         # Draw the A item in the A Frame of the HUD
@@ -351,8 +354,8 @@ class Level(metaclass=Singleton):
 
         item_a_id = None
         # Define here all swords implemented
-        if self.player.itemA == WOOD_SWORD_LABEL:
-            item_a_id = WOOD_SWORD_FRAME_ID
+        if self.player.itemA == cfg.WOOD_SWORD_LABEL:
+            item_a_id = cfg.WOOD_SWORD_FRAME_ID
 
         if self.equipped_item_a_sprite:
             self.equipped_item_a_sprite.kill()
@@ -376,13 +379,13 @@ class Level(metaclass=Singleton):
             self.equipped_item_b_sprite.kill()
 
         # Get selected item B id
-        if self.player.itemB == BOOMERANG_LABEL:
-            item_frame_id = BOOMERANG_FRAME_ID
-        elif self.player.itemB == BOMB_LABEL:
-            item_frame_id = BOMB_FRAME_ID
-        elif self.player.itemB == CANDLE_LABEL:
-            item_frame_id = RED_CANDLE_FRAME_ID
-        elif self.player.itemB == NONE_LABEL:
+        if self.player.itemB == cfg.BOOMERANG_LABEL:
+            item_frame_id = cfg.BOOMERANG_FRAME_ID
+        elif self.player.itemB == cfg.BOMB_LABEL:
+            item_frame_id = cfg.BOMB_FRAME_ID
+        elif self.player.itemB == cfg.CANDLE_LABEL:
+            item_frame_id = cfg.RED_CANDLE_FRAME_ID
+        elif self.player.itemB == cfg.NONE_LABEL:
             item_frame_id = None
         else:
             # Item B not implemented, abort
@@ -396,48 +399,48 @@ class Level(metaclass=Singleton):
     def load_warps(self, level_id, warp_type):
         image = None
         revealed = False
-        warp_file_path = MAPS_PATH + str(level_id)
+        warp_file_path = cfg.MAPS_PATH + str(level_id)
         ignore_non_existing_file = False
-        if warp_type == WARP_WARPS:
-            warp_file_path += MAPS_WARP
+        if warp_type == cfg.WARP_WARPS:
+            warp_file_path += cfg.MAPS_WARP
             groups = (self.warp_sprites,)
-        elif warp_type == WARP_BOMB:
+        elif warp_type == cfg.WARP_BOMB:
             ignore_non_existing_file = True
-            warp_file_path += MAPS_BOMB
+            warp_file_path += cfg.MAPS_BOMB
             groups = (self.visible_sprites, self.secret_bomb_sprites)
-            if DUNGEON_PREFIX_LABEL in level_id:
-                image = tileset.WARPS_TILE_SET.get_sprite_image(SECRET_WALL_FRAME_ID)
+            if cfg.DUNGEON_PREFIX_LABEL in level_id:
+                image = tileset.WARPS_TILE_SET.get_sprite_image(cfg.SECRET_WALL_FRAME_ID)
             else:
-                image = tileset.WARPS_TILE_SET.get_sprite_image(SECRET_CAVE_FRAME_ID)
-            if level_id in MAP_SECRETS_REVEALED.keys():
-                revealed = MAP_SECRETS_REVEALED[level_id]
+                image = tileset.WARPS_TILE_SET.get_sprite_image(cfg.SECRET_CAVE_FRAME_ID)
+            if level_id in cfg.MAP_SECRETS_REVEALED.keys():
+                revealed = cfg.MAP_SECRETS_REVEALED[level_id]
             else:
                 revealed = False
-        elif warp_type == WARP_FLAME:
+        elif warp_type == cfg.WARP_FLAME:
             ignore_non_existing_file = True
-            warp_file_path += MAPS_FLAME
+            warp_file_path += cfg.MAPS_FLAME
             groups = (self.visible_sprites, self.secret_flame_sprites)
-            image = tileset.WARPS_TILE_SET.get_sprite_image(SECRET_STAIRS_FRAME_ID)
-            if level_id in MAP_SECRETS_REVEALED.keys():
-                revealed = MAP_SECRETS_REVEALED[level_id]
+            image = tileset.WARPS_TILE_SET.get_sprite_image(cfg.SECRET_STAIRS_FRAME_ID)
+            if level_id in cfg.MAP_SECRETS_REVEALED.keys():
+                revealed = cfg.MAP_SECRETS_REVEALED[level_id]
             else:
                 revealed = False
         else:
             # warp type not implemented, abort
             return
-        layout = import_csv_layout(f'{warp_file_path}{MAPS_EXTENSION}', ignore_non_existing_file)
+        layout = import_csv_layout(f'{warp_file_path}{cfg.MAPS_EXTENSION}', ignore_non_existing_file)
 
         if layout is not None:
             for row_index, row in enumerate(layout):
                 for col_index, col in enumerate(row):
-                    x = col_index * TILE_SIZE
+                    x = col_index * cfg.TILE_SIZE
                     # Skipping the HUD tiles at the top of screen
-                    y = row_index * TILE_SIZE + HUD_OFFSET
+                    y = row_index * cfg.TILE_SIZE + cfg.HUD_OFFSET
                     sprite_id = int(col)
                     if sprite_id != -1:
-                        if warp_type == WARP_WARPS:
+                        if warp_type == cfg.WARP_WARPS:
                             Warp((x, y), groups, sprite_id, self.player)
-                        elif warp_type == WARP_BOMB:
+                        elif warp_type == cfg.WARP_BOMB:
                             SecretPassage((x, y),
                                           groups,
                                           self.obstacle_sprites,
@@ -446,7 +449,7 @@ class Level(metaclass=Singleton):
                                           self.player,
                                           image,
                                           revealed)
-                        elif warp_type == WARP_FLAME:
+                        elif warp_type == cfg.WARP_FLAME:
                             SecretPassage((x, y),
                                           groups,
                                           self.obstacle_sprites,
@@ -457,135 +460,135 @@ class Level(metaclass=Singleton):
                                           revealed)
 
     def load_limits(self, level_id):
-        layout = import_csv_layout(f'{MAPS_PATH}{level_id}{MAPS_LIMITS}{MAPS_EXTENSION}')
+        layout = import_csv_layout(f'{cfg.MAPS_PATH}{level_id}{cfg.MAPS_LIMITS}{cfg.MAPS_EXTENSION}')
         # Draw lines of obstacles so no one gets into the menu or off the screen at the bottom
-        for col in range(0, NB_TILE_WIDTH):
-            y_top = HUD_OFFSET - TILE_SIZE
-            y_bottom = SCREEN_HEIGHT
-            Obstacle((col*TILE_SIZE, y_top), (self.obstacle_sprites, self.border_sprites))
-            Obstacle((col*TILE_SIZE, y_bottom), (self.obstacle_sprites, self.border_sprites))
+        for col in range(0, cfg.NB_TILE_WIDTH):
+            y_top = cfg.HUD_OFFSET - cfg.TILE_SIZE
+            y_bottom = cfg.SCREEN_HEIGHT
+            Obstacle((col*cfg.TILE_SIZE, y_top), (self.obstacle_sprites, self.border_sprites))
+            Obstacle((col*cfg.TILE_SIZE, y_bottom), (self.obstacle_sprites, self.border_sprites))
         # Draw lines of obstacles so no one gets out of the sides of the screen
-        for row in range(HUD_TILE_HEIGHT, NB_TILE_HEIGHT):
-            x_left = - TILE_SIZE
-            x_right = SCREEN_WIDTH
-            Obstacle((x_left, row*TILE_SIZE), (self.obstacle_sprites, self.border_sprites))
-            Obstacle((x_right, row*TILE_SIZE), (self.obstacle_sprites, self.border_sprites))
+        for row in range(cfg.HUD_TILE_HEIGHT, cfg.NB_TILE_HEIGHT):
+            x_left = - cfg.TILE_SIZE
+            x_right = cfg.SCREEN_WIDTH
+            Obstacle((x_left, row*cfg.TILE_SIZE), (self.obstacle_sprites, self.border_sprites))
+            Obstacle((x_right, row*cfg.TILE_SIZE), (self.obstacle_sprites, self.border_sprites))
 
         # Draw obstacles inside the level layout
         for row_index, row in enumerate(layout):
             for col_index, col in enumerate(row):
-                x = col_index * TILE_SIZE
-                y = row_index * TILE_SIZE + HUD_OFFSET  # skipping menu tiles at the top of screen
+                x = col_index * cfg.TILE_SIZE
+                y = row_index * cfg.TILE_SIZE + cfg.HUD_OFFSET  # skipping menu tiles at the top of screen
                 sprite_id = int(col)
                 if sprite_id != -1:
                     Obstacle((x, y), (self.obstacle_sprites,), sprite_id)
 
     def load_items(self, level_id):
-        layout = import_csv_layout(f'{MAPS_PATH}{level_id}{MAPS_ITEMS}{MAPS_EXTENSION}', True)
+        layout = import_csv_layout(f'{cfg.MAPS_PATH}{level_id}{cfg.MAPS_ITEMS}{cfg.MAPS_EXTENSION}', True)
         # Ignore all items for levels that are not supposed to have any
-        if layout is not None and level_id in MAP_ITEMS.keys():
-            map_items = MAP_ITEMS[level_id].keys()
+        if layout is not None and level_id in cfg.MAP_ITEMS.keys():
+            map_items = cfg.MAP_ITEMS[level_id].keys()
             for row_index, row in enumerate(layout):
                 for col_index, col in enumerate(row):
-                    x = col_index * TILE_SIZE
-                    y = row_index * TILE_SIZE + HUD_OFFSET  # Skipping menu tiles at the top of screen
+                    x = col_index * cfg.TILE_SIZE
+                    y = row_index * cfg.TILE_SIZE + cfg.HUD_OFFSET  # Skipping menu tiles at the top of screen
                     sprite_id = int(col)
                     # Ignore any item that has an id that is not supposed to be in this level
-                    if (sprite_id == HEARTRECEPTACLE_FRAME_ID
-                            and HEARTRECEPTACLE_LABEL in map_items
-                            and MAP_ITEMS[level_id][HEARTRECEPTACLE_LABEL]):
+                    if (sprite_id == cfg.HEARTRECEPTACLE_FRAME_ID
+                            and cfg.HEARTRECEPTACLE_LABEL in map_items
+                            and cfg.MAP_ITEMS[level_id][cfg.HEARTRECEPTACLE_LABEL]):
                         HeartReceptacle((x, y),
                                         (self.visible_sprites, self.lootable_items_sprites),
                                         level_id)
-                    elif sprite_id == LADDER_FRAME_ID and MAP_ITEMS[level_id][LADDER_LABEL]:
+                    elif sprite_id == cfg.LADDER_FRAME_ID and cfg.MAP_ITEMS[level_id][cfg.LADDER_LABEL]:
                         Ladder((x, y),
                                (self.visible_sprites, self.lootable_items_sprites),
                                level_id)
-                    elif sprite_id == RED_CANDLE_FRAME_ID and MAP_ITEMS[level_id][CANDLE_LABEL]:
+                    elif sprite_id == cfg.RED_CANDLE_FRAME_ID and cfg.MAP_ITEMS[level_id][cfg.CANDLE_LABEL]:
                         RedCandle((x, y),
                                   (self.visible_sprites, self.lootable_items_sprites),
                                   level_id)
-                    elif sprite_id == BOOMERANG_FRAME_ID and MAP_ITEMS[level_id][BOOMERANG_LABEL]:
+                    elif sprite_id == cfg.BOOMERANG_FRAME_ID and cfg.MAP_ITEMS[level_id][cfg.BOOMERANG_LABEL]:
                         Boomerang((x, y),
                                   (self.visible_sprites, self.lootable_items_sprites),
                                   level_id)
-                    elif sprite_id == WOOD_SWORD_FRAME_ID and MAP_ITEMS[level_id][WOOD_SWORD_LABEL]:
+                    elif sprite_id == cfg.WOOD_SWORD_FRAME_ID and cfg.MAP_ITEMS[level_id][cfg.WOOD_SWORD_LABEL]:
                         WoodenSword((x, y),
                                     (self.visible_sprites, self.lootable_items_sprites),
                                     level_id)
-                    elif sprite_id == KEY_FRAME_ID and MAP_ITEMS[level_id][KEY_LABEL]:
+                    elif sprite_id == cfg.KEY_FRAME_ID and cfg.MAP_ITEMS[level_id][cfg.KEY_LABEL]:
                         Key((x, y),
                             (self.visible_sprites, self.lootable_items_sprites, self.particle_sprites),
                             level_id)
-                    elif sprite_id == TRIFORCE_FRAME_ID and MAP_ITEMS[level_id][TRIFORCE_LABEL]:
+                    elif sprite_id == cfg.TRIFORCE_FRAME_ID and cfg.MAP_ITEMS[level_id][cfg.TRIFORCE_LABEL]:
                         Triforce((x, y),
                                  (self.visible_sprites, self.lootable_items_sprites),
                                  level_id)
 
     def load_enemies(self, level_id):
-        layout = import_csv_layout(f'{MAPS_PATH}{level_id}{MAPS_ENEMIES}{MAPS_EXTENSION}', True)
+        layout = import_csv_layout(f'{cfg.MAPS_PATH}{level_id}{cfg.MAPS_ENEMIES}{cfg.MAPS_EXTENSION}', True)
         self.enemies_spawned_in_the_room = 0
         self.monsters_killed_in_the_room = 0
         if (layout is not None
-                and ((DUNGEON_PREFIX_LABEL in level_id and not DUNGEON_DECIMATION[level_id])
-                     or LEVEL_PREFIX_LABEL in level_id)):
+                and ((cfg.DUNGEON_PREFIX_LABEL in level_id and not cfg.DUNGEON_DECIMATION[level_id])
+                     or cfg.LEVEL_PREFIX_LABEL in level_id)):
             for row_index, row in enumerate(layout):
                 for col_index, col in enumerate(row):
-                    x = col_index * TILE_SIZE
-                    y = row_index * TILE_SIZE + HUD_OFFSET  # Skipping menu tiles at the top of screen
+                    x = col_index * cfg.TILE_SIZE
+                    y = row_index * cfg.TILE_SIZE + cfg.HUD_OFFSET  # Skipping menu tiles at the top of screen
                     sprite_id = int(col)
                     self.enemies_spawned_in_the_room += 1
-                    if sprite_id == RED_OCTOROCK_WALKING_DOWN_FRAME_ID:
+                    if sprite_id == cfg.RED_OCTOROCK_WALKING_DOWN_FRAME_ID:
                         RedOctorock((x, y),
                                     (self.visible_sprites, self.enemy_sprites),
                                     self.visible_sprites,
                                     self.obstacle_sprites,
                                     self.particle_sprites)
-                    elif sprite_id == BLUE_OCTOROCK_WALKING_DOWN_FRAME_ID:
+                    elif sprite_id == cfg.BLUE_OCTOROCK_WALKING_DOWN_FRAME_ID:
                         BlueOctorock((x, y),
                                      (self.visible_sprites, self.enemy_sprites),
                                      self.visible_sprites,
                                      self.obstacle_sprites,
                                      self.particle_sprites)
-                    elif sprite_id == RED_MOBLIN_WALKING_DOWN_FRAME_ID:
+                    elif sprite_id == cfg.RED_MOBLIN_WALKING_DOWN_FRAME_ID:
                         RedMoblin((x, y),
                                   (self.visible_sprites, self.enemy_sprites),
                                   self.visible_sprites,
                                   self.obstacle_sprites,
                                   self.particle_sprites)
-                    elif sprite_id == BLACK_MOBLIN_WALKING_DOWN_FRAME_ID:
+                    elif sprite_id == cfg.BLACK_MOBLIN_WALKING_DOWN_FRAME_ID:
                         BlackMoblin((x, y),
                                     (self.visible_sprites, self.enemy_sprites),
                                     self.visible_sprites,
                                     self.obstacle_sprites,
                                     self.particle_sprites)
-                    elif sprite_id == STALFOS_WALKING_FRAME_ID:
+                    elif sprite_id == cfg.STALFOS_WALKING_FRAME_ID:
                         Stalfos((x, y),
                                 (self.visible_sprites, self.enemy_sprites),
                                 self.visible_sprites,
                                 self.obstacle_sprites,
                                 self.particle_sprites)
-                    elif sprite_id == GORIYA_WALKING_DOWN_FRAME_ID:
+                    elif sprite_id == cfg.GORIYA_WALKING_DOWN_FRAME_ID:
                         Goriya((x, y),
                                (self.visible_sprites, self.enemy_sprites),
                                self.visible_sprites,
                                self.obstacle_sprites,
                                self.particle_sprites,
                                self.border_sprites)
-                    elif sprite_id == DARKNUT_WALKING_DOWN_FRAME_ID:
+                    elif sprite_id == cfg.DARKNUT_WALKING_DOWN_FRAME_ID:
                         Darknut((x, y),
                                 (self.visible_sprites, self.enemy_sprites),
                                 self.visible_sprites,
                                 self.obstacle_sprites,
                                 self.particle_sprites,
                                 self.border_sprites)
-                    elif sprite_id == ZORA_WALKING_DOWN_FRAME_ID:
+                    elif sprite_id == cfg.ZORA_WALKING_DOWN_FRAME_ID:
                         Zora((x, y),
                              (self.visible_sprites, self.enemy_sprites),
                              self.visible_sprites,
                              self.obstacle_sprites,
                              self.particle_sprites)
-                    elif sprite_id == LEEVER_WALKING_FRAME_ID:
+                    elif sprite_id == cfg.LEEVER_WALKING_FRAME_ID:
                         Leever((x, y),
                                (self.visible_sprites, self.enemy_sprites),
                                self.visible_sprites,
@@ -597,69 +600,69 @@ class Level(metaclass=Singleton):
 
     def load_shop(self, level_id):
         # Shops display from 0 to 3 items max
-        if level_id in SHOPS.keys() and ITEMS_LABEL in SHOPS[level_id].keys():
-            nb_items = len(SHOPS[level_id][ITEMS_LABEL].keys())
+        if level_id in cfg.SHOPS.keys() and cfg.ITEMS_LABEL in cfg.SHOPS[level_id].keys():
+            nb_items = len(cfg.SHOPS[level_id][cfg.ITEMS_LABEL].keys())
             item_pos = []
 
             match nb_items:
                 case 0:
                     pass
                 case 1:
-                    item_pos.append((15 * TILE_SIZE, ITEM_Y))
+                    item_pos.append((15 * cfg.TILE_SIZE, cfg.ITEM_Y))
                 case 2:
-                    item_pos.append((12 * TILE_SIZE, ITEM_Y))
-                    item_pos.append((18 * TILE_SIZE, ITEM_Y))
+                    item_pos.append((12 * cfg.TILE_SIZE, cfg.ITEM_Y))
+                    item_pos.append((18 * cfg.TILE_SIZE, cfg.ITEM_Y))
                 case _:
-                    item_pos.append((10 * TILE_SIZE, ITEM_Y))
-                    item_pos.append((15 * TILE_SIZE, ITEM_Y))
-                    item_pos.append((20 * TILE_SIZE, ITEM_Y))
+                    item_pos.append((10 * cfg.TILE_SIZE, cfg.ITEM_Y))
+                    item_pos.append((15 * cfg.TILE_SIZE, cfg.ITEM_Y))
+                    item_pos.append((20 * cfg.TILE_SIZE, cfg.ITEM_Y))
                     nb_items = 3
 
-            flame_images = [tileset.NPCS_TILE_SET.get_sprite_image(NPC_FLAME_ID),
-                            pygame.transform.flip(tileset.NPCS_TILE_SET.get_sprite_image(NPC_FLAME_ID),
+            flame_images = [tileset.NPCS_TILE_SET.get_sprite_image(cfg.NPC_FLAME_ID),
+                            pygame.transform.flip(tileset.NPCS_TILE_SET.get_sprite_image(cfg.NPC_FLAME_ID),
                                                   True,
                                                   False)]
-            Npc(FLAME_1_POS, (self.visible_sprites, self.npc_sprites), flame_images)
-            Npc(FLAME_2_POS, (self.visible_sprites, self.npc_sprites), flame_images)
+            Npc(cfg.FLAME_1_POS, (self.visible_sprites, self.npc_sprites), flame_images)
+            Npc(cfg.FLAME_2_POS, (self.visible_sprites, self.npc_sprites), flame_images)
 
             # Caution : in python, 0 == False, so if npc_id is 0, this code is never executed
-            npc_id = SHOPS[level_id][NPC_ID_LABEL]
+            npc_id = cfg.SHOPS[level_id][cfg.NPC_ID_LABEL]
             if npc_id:
                 npc_images = [tileset.NPCS_TILE_SET.get_sprite_image(npc_id)]
-                if SHOPS[level_id][NPC_ID_LABEL] in ANIMATED_FLIPPED_NPCS:
+                if cfg.SHOPS[level_id][cfg.NPC_ID_LABEL] in cfg.ANIMATED_FLIPPED_NPCS:
                     npc_images.append(pygame.transform.flip(npc_images[0],
                                                             True,
                                                             False))
-                Npc((NPC_X, NPC_Y), (self.visible_sprites, self.npc_sprites), npc_images)
+                Npc((cfg.NPC_X, cfg.NPC_Y), (self.visible_sprites, self.npc_sprites), npc_images)
 
-            if SHOPS[level_id][TEXT_LABEL] and nb_items > 0:
-                text_pos_y = TEXT_OFFSET + HUD_OFFSET
+            if cfg.SHOPS[level_id][cfg.TEXT_LABEL] and nb_items > 0:
+                text_pos_y = cfg.TEXT_OFFSET + cfg.HUD_OFFSET
                 TextBlock((self.visible_sprites, self.text_sprites),
-                          SHOPS[level_id][TEXT_LABEL],
+                          cfg.SHOPS[level_id][cfg.TEXT_LABEL],
                           text_pos_y)
 
-            items = list(SHOPS[level_id][ITEMS_LABEL].items())
+            items = list(cfg.SHOPS[level_id][cfg.ITEMS_LABEL].items())
             for i in range(nb_items):
                 item_label, item_price = items[i]
-                if item_label in SHOP_CONSUMABLES:
+                if item_label in cfg.SHOP_CONSUMABLES:
                     tile_set = tileset.CONSUMABLES_TILE_SET
-                    item_image = tile_set.get_sprite_image(SHOP_CONSUMABLES[item_label])
-                elif item_label in SHOP_ITEMS:
+                    item_image = tile_set.get_sprite_image(cfg.SHOP_CONSUMABLES[item_label])
+                elif item_label in cfg.SHOP_ITEMS:
                     tile_set = tileset.ITEMS_TILE_SET
-                    item_image = tile_set.get_sprite_image(SHOP_ITEMS[item_label])
+                    item_image = tile_set.get_sprite_image(cfg.SHOP_ITEMS[item_label])
                 else:
                     # Unidentified item, implement it in settings.py
                     # Abort
                     return
 
                 price_sprite = None
-                if item_label != RUPEE_LABEL and item_price > 0:
-                    price_x = item_pos[i][0] + TILE_SIZE - FONT_SPRITE_SIZE // 2
+                if item_label != cfg.RUPEE_LABEL and item_price > 0:
+                    price_x = item_pos[i][0] + cfg.TILE_SIZE - cfg.FONT_SPRITE_SIZE // 2
                     if item_price // 100 != 0:
-                        price_x -= FONT_SPRITE_SIZE
+                        price_x -= cfg.FONT_SPRITE_SIZE
                     elif item_price // 10 != 0:
-                        price_x -= FONT_SPRITE_SIZE // 2
-                    price_y = item_pos[i][1] + 3 * TILE_SIZE
+                        price_x -= cfg.FONT_SPRITE_SIZE // 2
+                    price_y = item_pos[i][1] + 3 * cfg.TILE_SIZE
                     price_sprite = TextBlock((self.visible_sprites, self.text_sprites),
                                              str(item_price),
                                              price_y,
@@ -673,8 +676,8 @@ class Level(metaclass=Singleton):
                             price_sprite)
 
     def load_doors(self, level_id):
-        if DUNGEON_PREFIX_LABEL in level_id and level_id in DUNGEON_DOORS.keys():
-            for door_pos, door_type in DUNGEON_DOORS[level_id].items():
+        if cfg.DUNGEON_PREFIX_LABEL in level_id and level_id in cfg.DUNGEON_DOORS.keys():
+            for door_pos, door_type in cfg.DUNGEON_DOORS[level_id].items():
                 Door((self.visible_sprites, self.door_sprites),
                      door_pos,
                      door_type)
@@ -698,9 +701,9 @@ class Level(metaclass=Singleton):
         # This creates all Sprites of the new map
         # This is done AFTER any map change animation
         self.load_limits(level_id)
-        self.load_warps(level_id, WARP_WARPS)
-        self.load_warps(level_id, WARP_BOMB)
-        self.load_warps(level_id, WARP_FLAME)
+        self.load_warps(level_id, cfg.WARP_WARPS)
+        self.load_warps(level_id, cfg.WARP_BOMB)
+        self.load_warps(level_id, cfg.WARP_FLAME)
         self.load_doors(level_id)
         self.load_items(level_id)
         self.load_enemies(level_id)
@@ -714,28 +717,28 @@ class Level(metaclass=Singleton):
         next_floor_y = 0
         current_floor_x = 0
         current_floor_y = 0
-        if self.in_map_transition == MAP_TRANSITION_UP:
-            if LEVEL_PREFIX_LABEL in self.current_map:
-                next_level_id = int(self.current_map_screen) - NB_MAPS_PER_ROW[OVERWORLD_LABEL]
+        if self.in_map_transition == cfg.MAP_TRANSITION_UP:
+            if cfg.LEVEL_PREFIX_LABEL in self.current_map:
+                next_level_id = int(self.current_map_screen) - cfg.NB_MAPS_PER_ROW[cfg.OVERWORLD_LABEL]
             else:
-                next_level_id = int(self.current_map_screen) - NB_MAPS_PER_ROW[DUNGEON_LABEL]
+                next_level_id = int(self.current_map_screen) - cfg.NB_MAPS_PER_ROW[cfg.DUNGEON_LABEL]
             self.transition_surface = pygame.Surface(
                 (self.floor_rect.width, 2 * self.floor_rect.height))
             current_floor_y = self.floor_rect.height
-        elif self.in_map_transition == MAP_TRANSITION_RIGHT:
+        elif self.in_map_transition == cfg.MAP_TRANSITION_RIGHT:
             next_level_id = int(self.current_map_screen) + 1
             self.transition_surface = pygame.Surface(
                 (2 * self.floor_rect.width, self.floor_rect.height))
             next_floor_x = self.floor_rect.width
-        elif self.in_map_transition == MAP_TRANSITION_DOWN:
-            if LEVEL_PREFIX_LABEL in self.current_map:
-                next_level_id = int(self.current_map_screen) + NB_MAPS_PER_ROW[OVERWORLD_LABEL]
+        elif self.in_map_transition == cfg.MAP_TRANSITION_DOWN:
+            if cfg.LEVEL_PREFIX_LABEL in self.current_map:
+                next_level_id = int(self.current_map_screen) + cfg.NB_MAPS_PER_ROW[cfg.OVERWORLD_LABEL]
             else:
-                next_level_id = int(self.current_map_screen) + NB_MAPS_PER_ROW[DUNGEON_LABEL]
+                next_level_id = int(self.current_map_screen) + cfg.NB_MAPS_PER_ROW[cfg.DUNGEON_LABEL]
             self.transition_surface = pygame.Surface(
                 (self.floor_rect.width, 2 * self.floor_rect.height))
             next_floor_y = self.floor_rect.height
-        elif self.in_map_transition == MAP_TRANSITION_LEFT:
+        elif self.in_map_transition == cfg.MAP_TRANSITION_LEFT:
             next_level_id = int(self.current_map_screen) - 1
             self.transition_surface = pygame.Surface(
                 (2 * self.floor_rect.width, self.floor_rect.height))
@@ -744,7 +747,8 @@ class Level(metaclass=Singleton):
             # Undefined warp transition, abort
             return
 
-        next_floor = pygame.image.load(f'{LEVELS_PATH}{self.current_map}{next_level_id}{GRAPHICS_EXTENSION}').convert()
+        next_floor = pygame.image.load(f'{cfg.LEVELS_PATH}{self.current_map}{next_level_id}{cfg.GRAPHICS_EXTENSION}'
+                                       ).convert()
         self.transition_surface.blit(next_floor, (next_floor_x, next_floor_y))
         self.transition_surface.blit(self.floor_surface, (current_floor_x, current_floor_y))
         self.next_map_screen = next_level_id
@@ -779,73 +783,73 @@ class Level(metaclass=Singleton):
 
             # change_id 0 -> 3 is a side scrolling map change, respectively Up/Right/Down/Left
             # change_id > 3 is a stairs map change, with sound and a completely different map
-            if DUNGEON_PREFIX_LABEL in self.current_map:
-                new_state = STATE_WARPING_DUNGEON
+            if cfg.DUNGEON_PREFIX_LABEL in self.current_map:
+                new_state = cfg.STATE_WARPING_DUNGEON
             else:
-                new_state = STATE_WARPING
+                new_state = cfg.STATE_WARPING
             match change_id:
                 case 0:
                     # Up
-                    self.in_map_transition = MAP_TRANSITION_UP
+                    self.in_map_transition = cfg.MAP_TRANSITION_UP
                     self.create_transition_surface()
                     self.player.set_state(new_state)
                     # Animate slide - will be done in update
                 case 1:
                     # Right
-                    self.in_map_transition = MAP_TRANSITION_RIGHT
+                    self.in_map_transition = cfg.MAP_TRANSITION_RIGHT
                     self.create_transition_surface()
                     self.player.set_state(new_state)
                     # Animate slide - will be done in update
                 case 2:
                     # Down
-                    self.in_map_transition = MAP_TRANSITION_DOWN
+                    self.in_map_transition = cfg.MAP_TRANSITION_DOWN
                     self.create_transition_surface()
                     self.player.set_state(new_state)
                     # Animate slide - will be done in update
                 case 3:
                     # Left
-                    self.in_map_transition = MAP_TRANSITION_LEFT
+                    self.in_map_transition = cfg.MAP_TRANSITION_LEFT
                     self.create_transition_surface()
                     self.player.set_state(new_state)
                     # Animate slide - will be done in update
                 case _:
-                    if change_id - 4 < len(UNDERWORLD_STAIRS):
-                        if UNDERWORLD_STAIRS[change_id - 4][STAIRS_LABEL]:
-                            self.in_map_transition = MAP_TRANSITION_STAIRS
-                            self.player.set_state(STATE_STAIRS)
+                    if change_id - 4 < len(cfg.UNDERWORLD_STAIRS):
+                        if cfg.UNDERWORLD_STAIRS[change_id - 4][cfg.STAIRS_LABEL]:
+                            self.in_map_transition = cfg.MAP_TRANSITION_STAIRS
+                            self.player.set_state(cfg.STATE_STAIRS)
                             self.stairs_animation_starting_time = pygame.time.get_ticks()
                         else:
-                            self.in_map_transition = MAP_TRANSITION_SILENT
+                            self.in_map_transition = cfg.MAP_TRANSITION_SILENT
 
-                        self.next_map = UNDERWORLD_STAIRS[change_id - 4][MAP_LABEL]
-                        self.next_map_screen = UNDERWORLD_STAIRS[change_id - 4][SCREEN_LABEL]
-                        self.player_new_position = UNDERWORLD_STAIRS[change_id - 4][PLAYER_POS_LABEL]
+                        self.next_map = cfg.UNDERWORLD_STAIRS[change_id - 4][cfg.MAP_LABEL]
+                        self.next_map_screen = cfg.UNDERWORLD_STAIRS[change_id - 4][cfg.SCREEN_LABEL]
+                        self.player_new_position = cfg.UNDERWORLD_STAIRS[change_id - 4][cfg.PLAYER_POS_LABEL]
 
     def animate_map_transition(self):
         self.map_scroll_animation_counter += 1
-        x_fixed_offset = self.floor_rect.width / MAP_SCROLL_FRAMES_COUNT
-        y_fixed_offset = self.floor_rect.height / MAP_SCROLL_FRAMES_COUNT
+        x_fixed_offset = self.floor_rect.width / cfg.MAP_SCROLL_FRAMES_COUNT
+        y_fixed_offset = self.floor_rect.height / cfg.MAP_SCROLL_FRAMES_COUNT
         x_offset = x_fixed_offset * self.map_scroll_animation_counter
         y_offset = y_fixed_offset * self.map_scroll_animation_counter
 
-        if self.in_map_transition == MAP_TRANSITION_UP:
-            self.display_surface.blit(self.transition_surface, (0, HUD_OFFSET - self.floor_rect.height + y_offset))
+        if self.in_map_transition == cfg.MAP_TRANSITION_UP:
+            self.display_surface.blit(self.transition_surface, (0, cfg.HUD_OFFSET - self.floor_rect.height + y_offset))
             self.draw_hud()
             self.player.define_warping_position(0, y_offset, self.current_map)
-        elif self.in_map_transition == MAP_TRANSITION_RIGHT:
-            self.display_surface.blit(self.transition_surface, (-x_offset, HUD_OFFSET))
+        elif self.in_map_transition == cfg.MAP_TRANSITION_RIGHT:
+            self.display_surface.blit(self.transition_surface, (-x_offset, cfg.HUD_OFFSET))
             self.player.define_warping_position(-x_offset, 0, self.current_map)
-        elif self.in_map_transition == MAP_TRANSITION_DOWN:
-            self.display_surface.blit(self.transition_surface, (0, HUD_OFFSET - y_offset))
+        elif self.in_map_transition == cfg.MAP_TRANSITION_DOWN:
+            self.display_surface.blit(self.transition_surface, (0, cfg.HUD_OFFSET - y_offset))
             self.draw_hud()
             self.player.define_warping_position(0, -y_offset, self.current_map)
-        elif self.in_map_transition == MAP_TRANSITION_LEFT:
-            self.display_surface.blit(self.transition_surface, (x_offset - self.floor_rect.width, HUD_OFFSET))
+        elif self.in_map_transition == cfg.MAP_TRANSITION_LEFT:
+            self.display_surface.blit(self.transition_surface, (x_offset - self.floor_rect.width, cfg.HUD_OFFSET))
             self.player.define_warping_position(x_offset, 0, self.current_map)
 
     def palette_shift_floor(self, palette_in, palette_out, color_level):
         if len(palette_in) != len(palette_out[color_level]):
-            raise ValueError(INCOMPATIBLE_PALETTES)
+            raise ValueError(cfg.INCOMPATIBLE_PALETTES)
         for i in range(len(palette_in)):
             img_copy = self.floor_surface.copy()
             img_copy.fill(palette_out[color_level][i])
@@ -871,26 +875,26 @@ class Level(metaclass=Singleton):
         for merch in self.purchasable_sprites:
             merch.kill()
 
-        if self.victory_motion_index == 1 and self.victory_floor_index < len(WHITE_LIST):
+        if self.victory_motion_index == 1 and self.victory_floor_index < len(cfg.WHITE_LIST):
             if self.victory_floor_switch_starting_time == 0:
                 self.victory_floor_switch_starting_time = current_time
-            palette_in = PALETTE_NATURAL_DUNGEON
-            palette_out = PALETTE_TRIFORCE
-            self.palette_shift_floor(palette_in, palette_out, WHITE_LIST[self.victory_floor_index])
-            self.display_surface.blit(self.floor_surface, (0, HUD_OFFSET))
+            palette_in = cfg.PALETTE_NATURAL_DUNGEON
+            palette_out = cfg.PALETTE_TRIFORCE
+            self.palette_shift_floor(palette_in, palette_out, cfg.WHITE_LIST[self.victory_floor_index])
+            self.display_surface.blit(self.floor_surface, (0, cfg.HUD_OFFSET))
             if current_time - self.victory_floor_switch_starting_time >= self.victory_floor_switch_cooldown:
                 self.victory_floor_switch_starting_time = 0
                 self.victory_floor_index += 1
-        elif self.victory_motion_index == 1 and self.victory_floor_index == len(WHITE_LIST):
+        elif self.victory_motion_index == 1 and self.victory_floor_index == len(cfg.WHITE_LIST):
             self.victory_motion_index += 1
 
         if self.victory_motion_index > 1:
-            self.draw_floor(BLACK_LABEL)
+            self.draw_floor(cfg.BLACK_LABEL)
 
         if self.victory_motion_index == 2:
-            victory_message_pos_y = HUD_OFFSET + TILE_SIZE * 4
+            victory_message_pos_y = cfg.HUD_OFFSET + cfg.TILE_SIZE * 4
             TextBlock((self.visible_sprites,),
-                      VICTORY_TEXT,
+                      cfg.VICTORY_TEXT,
                       victory_message_pos_y)
             # If Victory Message goes over the triforce with blank lines or blank characters
             # it becomes hidden behind a black Surface. Putting it back on the foreground
@@ -935,7 +939,7 @@ class Level(metaclass=Singleton):
                 text.kill()
             if self.death_hurt_starting_time == 0:
                 self.death_hurt_starting_time = current_time
-                self.player.set_state(STATE_DYING)
+                self.player.set_state(cfg.STATE_DYING)
             elif current_time - self.death_hurt_starting_time >= self.death_hurt_cooldown:
                 self.death_motion_index += 1
                 self.game_over_sound.play()
@@ -943,49 +947,49 @@ class Level(metaclass=Singleton):
 
         # Set map img to red version
         if self.death_motion_index == 2:
-            if LEVEL_PREFIX_LABEL in self.current_map:
-                palette_in = PALETTE_NATURAL_LEVEL
-            elif DUNGEON_PREFIX_LABEL in self.current_map:
-                palette_in = PALETTE_NATURAL_DUNGEON
+            if cfg.LEVEL_PREFIX_LABEL in self.current_map:
+                palette_in = cfg.PALETTE_NATURAL_LEVEL
+            elif cfg.DUNGEON_PREFIX_LABEL in self.current_map:
+                palette_in = cfg.PALETTE_NATURAL_DUNGEON
             else:
-                palette_in = PALETTE_NATURAL_CAVE
-            self.palette_shift_floor(palette_in, PALETTE_DEATH, RED_LIST[self.death_floor_index])
-            self.display_surface.blit(self.floor_surface, (0, HUD_OFFSET))
+                palette_in = cfg.PALETTE_NATURAL_CAVE
+            self.palette_shift_floor(palette_in, cfg.PALETTE_DEATH, cfg.RED_LIST[self.death_floor_index])
+            self.display_surface.blit(self.floor_surface, (0, cfg.HUD_OFFSET))
             # Spin ! By default, 3 times (cf init of self.death_spin_cooldown)
             if current_time - self.death_spin_starting_time < self.death_spin_cooldown:
-                self.player.set_state(STATE_SPINNING)
+                self.player.set_state(cfg.STATE_SPINNING)
             else:
                 self.death_motion_index += 1
                 self.death_floor_index += 1
-                self.player.set_state(STATE_IDLE_DOWN)
+                self.player.set_state(cfg.STATE_IDLE_DOWN)
 
         # Switch map img to 3 darker shades successively
-        if self.death_motion_index == 3 and self.death_floor_index < len(RED_LIST):
+        if self.death_motion_index == 3 and self.death_floor_index < len(cfg.RED_LIST):
             if self.death_floor_switch_starting_time == 0:
                 self.death_floor_switch_starting_time = current_time
-            if LEVEL_PREFIX_LABEL in self.current_map:
-                palette_in = PALETTE_NATURAL_LEVEL
-            elif DUNGEON_PREFIX_LABEL in self.current_map:
-                palette_in = PALETTE_NATURAL_DUNGEON
+            if cfg.LEVEL_PREFIX_LABEL in self.current_map:
+                palette_in = cfg.PALETTE_NATURAL_LEVEL
+            elif cfg.DUNGEON_PREFIX_LABEL in self.current_map:
+                palette_in = cfg.PALETTE_NATURAL_DUNGEON
             else:
-                palette_in = PALETTE_NATURAL_CAVE
-            self.palette_shift_floor(palette_in, PALETTE_DEATH, RED_LIST[self.death_floor_index])
-            self.display_surface.blit(self.floor_surface, (0, HUD_OFFSET))
+                palette_in = cfg.PALETTE_NATURAL_CAVE
+            self.palette_shift_floor(palette_in, cfg.PALETTE_DEATH, cfg.RED_LIST[self.death_floor_index])
+            self.display_surface.blit(self.floor_surface, (0, cfg.HUD_OFFSET))
             if current_time - self.death_floor_switch_starting_time >= self.death_floor_switch_cooldown:
                 self.death_floor_switch_starting_time = 0
                 self.death_floor_index += 1
-        elif self.death_motion_index == 3 and self.death_floor_index == len(RED_LIST):
+        elif self.death_motion_index == 3 and self.death_floor_index == len(cfg.RED_LIST):
             self.death_motion_index += 1
 
         # No more floor, just black
         if self.death_motion_index > 3:
-            self.draw_floor(BLACK_LABEL)
+            self.draw_floor(cfg.BLACK_LABEL)
 
         # Put player in gray state for animation
         if self.death_motion_index == 4:
             if self.death_gray_starting_time == 0:
                 self.death_gray_starting_time = current_time
-                self.player.set_state(STATE_GRAY)
+                self.player.set_state(cfg.STATE_GRAY)
             if current_time - self.death_gray_starting_time >= self.death_gray_cooldown:
                 self.death_motion_index += 1
 
@@ -993,7 +997,7 @@ class Level(metaclass=Singleton):
         if self.death_motion_index == 5:
             if self.death_despawn_starting_time == 0:
                 self.death_despawn_starting_time = current_time
-                self.player.set_state(STATE_DESPAWN)
+                self.player.set_state(cfg.STATE_DESPAWN)
             if current_time - self.death_despawn_starting_time >= self.death_despawn_cooldown:
                 self.death_motion_index += 1
 
@@ -1004,9 +1008,9 @@ class Level(metaclass=Singleton):
 
         # Print GAME OVER in middle of screen until key is pressed to exit game
         if self.death_motion_index == 7:
-            game_over_message_pos_y = (SCREEN_HEIGHT // 2) + (HUD_OFFSET // 2) - (TILE_SIZE // 2)
+            game_over_message_pos_y = (cfg.SCREEN_HEIGHT // 2) + (cfg.HUD_OFFSET // 2) - (cfg.TILE_SIZE // 2)
             TextBlock((self.visible_sprites, self.text_sprites),
-                      GAME_OVER_TEXT,
+                      cfg.GAME_OVER_TEXT,
                       game_over_message_pos_y)
             self.death_motion_index += 1
 
@@ -1021,12 +1025,12 @@ class Level(metaclass=Singleton):
         return False
 
     def is_right_key_pressed_in_menu_with_item(self, keys):
-        if is_right_key_pressed(keys) and self.in_menu and self.current_selected_item != NONE_LABEL:
+        if is_right_key_pressed(keys) and self.in_menu and self.current_selected_item != cfg.NONE_LABEL:
             return True
         return False
 
     def is_left_key_pressed_in_menu_with_item(self, keys):
-        if is_left_key_pressed(keys) and self.in_menu and self.current_selected_item != NONE_LABEL:
+        if is_left_key_pressed(keys) and self.in_menu and self.current_selected_item != cfg.NONE_LABEL:
             return True
         return False
 
@@ -1094,11 +1098,11 @@ class Level(metaclass=Singleton):
         # From 0 to 9 : Rupee - Bombs - Rupee - Fairy - Rupee - Heart - Heart - Bombs - Rupee - Heart
         # 40% Rupee, 30% Heart, 20% Bombs, 10% Fairy
         self.kill_count += 1
-        if random.randint(1, 100) <= LOOT_DROP_PERCENTAGE:
+        if random.randint(1, 100) <= cfg.LOOT_DROP_PERCENTAGE:
             loot = self.kill_count % 10
             match loot:
                 case 0 | 2 | 4 | 8:
-                    rupee_amount = 5 if random.randint(1, 100) <= LOOT_BIG_RUPEE_PERCENTAGE else 1
+                    rupee_amount = 5 if random.randint(1, 100) <= cfg.LOOT_BIG_RUPEE_PERCENTAGE else 1
                     Rupee(pos, (self.visible_sprites, self.particle_sprites), rupee_amount)
                 case 1 | 7:
                     CBomb(pos, (self.visible_sprites, self.particle_sprites))
@@ -1108,25 +1112,25 @@ class Level(metaclass=Singleton):
                     Heart(pos, (self.visible_sprites, self.particle_sprites))
 
     def player_pick_up(self, item_label, amount=0):
-        if item_label in ITEM_PICKUP_ANIMATION.keys():
+        if item_label in cfg.ITEM_PICKUP_ANIMATION.keys():
             x_offset = 0 + self.player.direction_vector[0] * self.player.speed
-            y_offset = - TILE_SIZE * 2 + self.player.direction_vector[1] * self.player.speed
-            if item_label == HEARTRECEPTACLE_LABEL:
-                item_image = tileset.CONSUMABLES_TILE_SET.get_sprite_image(HEARTRECEPTACLE_FRAME_ID)
+            y_offset = - cfg.TILE_SIZE * 2 + self.player.direction_vector[1] * self.player.speed
+            if item_label == cfg.HEARTRECEPTACLE_LABEL:
+                item_image = tileset.CONSUMABLES_TILE_SET.get_sprite_image(cfg.HEARTRECEPTACLE_FRAME_ID)
                 x_offset += 1
                 y_offset += 4
-            elif item_label == WOOD_SWORD_LABEL:
-                item_image = tileset.ITEMS_TILE_SET.get_sprite_image(WOOD_SWORD_FRAME_ID)
+            elif item_label == cfg.WOOD_SWORD_LABEL:
+                item_image = tileset.ITEMS_TILE_SET.get_sprite_image(cfg.WOOD_SWORD_FRAME_ID)
                 x_offset -= 12
-            elif item_label == CANDLE_LABEL:
-                item_image = tileset.ITEMS_TILE_SET.get_sprite_image(RED_CANDLE_FRAME_ID)
+            elif item_label == cfg.CANDLE_LABEL:
+                item_image = tileset.ITEMS_TILE_SET.get_sprite_image(cfg.RED_CANDLE_FRAME_ID)
                 x_offset -= 12
-            elif item_label == BOOMERANG_LABEL:
-                item_image = tileset.ITEMS_TILE_SET.get_sprite_image(BOOMERANG_FRAME_ID)
+            elif item_label == cfg.BOOMERANG_LABEL:
+                item_image = tileset.ITEMS_TILE_SET.get_sprite_image(cfg.BOOMERANG_FRAME_ID)
                 x_offset -= 12
                 y_offset += 10
-            elif item_label == LADDER_LABEL:
-                item_image = tileset.ITEMS_TILE_SET.get_sprite_image(LADDER_FRAME_ID)
+            elif item_label == cfg.LADDER_LABEL:
+                item_image = tileset.ITEMS_TILE_SET.get_sprite_image(cfg.LADDER_FRAME_ID)
                 x_offset += 0
             else:
                 # Item not implemented yet ? abort
@@ -1136,14 +1140,14 @@ class Level(metaclass=Singleton):
             item_pos = (self.player.rect.left + x_offset, self.player.rect.top + y_offset)
             self.item_picked_up = Tile(item_pos, (self.visible_sprites,), item_image)
         else:
-            if (item_label == HEART_LABEL
-                    or item_label == FAIRY_LABEL):
+            if (item_label == cfg.HEART_LABEL
+                    or item_label == cfg.FAIRY_LABEL):
                 self.player.heal(amount)
-            elif item_label == RUPEE_LABEL:
+            elif item_label == cfg.RUPEE_LABEL:
                 self.player.add_money(amount)
-            elif item_label == BOMB_LABEL:
+            elif item_label == cfg.BOMB_LABEL:
                 self.player.add_bombs(amount)
-            elif item_label == KEY_LABEL:
+            elif item_label == cfg.KEY_LABEL:
                 self.player.add_keys(amount)
             else:
                 # Item not implemented yet ? abort
@@ -1152,65 +1156,66 @@ class Level(metaclass=Singleton):
     def map_kill_event_done(self):
         self.event_cleared_sound.play()
         level_id = str(self.current_map) + str(self.current_map_screen)
-        event_label = MONSTER_KILL_EVENT[level_id]
-        item_pos = (SCREEN_WIDTH // 2 - TILE_SIZE, (SCREEN_HEIGHT + HUD_OFFSET) // 2 - TILE_SIZE)
-        if event_label == BOMB_LABEL:
+        event_label = cfg.MONSTER_KILL_EVENT[level_id]
+        item_pos = (cfg.SCREEN_WIDTH // 2 - cfg.TILE_SIZE, (cfg.SCREEN_HEIGHT + cfg.HUD_OFFSET) // 2 - cfg.TILE_SIZE)
+        if event_label == cfg.BOMB_LABEL:
             CBomb(item_pos,
                   (self.visible_sprites, self.particle_sprites),
                   True)
-        elif event_label == RUPEE_LABEL:
+        elif event_label == cfg.RUPEE_LABEL:
             Rupee(item_pos,
                   (self.visible_sprites, self.particle_sprites),
-                  DUNGEON_RUPEE_AMOUNT,
+                  cfg.DUNGEON_RUPEE_AMOUNT,
                   True)
-        elif event_label == HEART_LABEL:
+        elif event_label == cfg.HEART_LABEL:
             Heart(item_pos,
                   (self.visible_sprites, self.particle_sprites),
                   True)
-        elif event_label == KEY_LABEL:
+        elif event_label == cfg.KEY_LABEL:
             Key(item_pos,
                 (self.visible_sprites, self.particle_sprites),
                 level_id,
                 True)
-        elif event_label == HEARTRECEPTACLE_LABEL:
+        elif event_label == cfg.HEARTRECEPTACLE_LABEL:
             HeartReceptacle(item_pos,
                             (self.visible_sprites, self.particle_sprites),
                             level_id,
                             True)
-        elif event_label == BOOMERANG_LABEL:
+        elif event_label == cfg.BOOMERANG_LABEL:
             Boomerang(item_pos,
                       (self.visible_sprites, self.lootable_items_sprites),
                       level_id,
                       True)
-        elif event_label == OPEN_DOORS_LABEL:
+        elif event_label == cfg.OPEN_DOORS_LABEL:
             for door in self.door_sprites:
-                if door.type == DOOR_EVENT_LABEL:
+                if door.type == cfg.DOOR_EVENT_LABEL:
                     door.open()
         self.dead_monsters_event_played = True
 
     def pick_up_triforce(self):
         # Put the Triforce in the hands of the Player
-        self.player.set_position((SCREEN_WIDTH // 2 - TILE_SIZE, SCREEN_HEIGHT // 2 + HUD_OFFSET // 2 - TILE_SIZE))
-        y_offset = - TILE_SIZE * 2 + self.player.direction_vector[1] * self.player.speed
-        item_image = tileset.ITEMS_TILE_SET.get_sprite_image(TRIFORCE_FRAME_ID)
+        self.player.set_position((cfg.SCREEN_WIDTH // 2 - cfg.TILE_SIZE,
+                                  cfg.SCREEN_HEIGHT // 2 + cfg.HUD_OFFSET // 2 - cfg.TILE_SIZE))
+        y_offset = - cfg.TILE_SIZE * 2 + self.player.direction_vector[1] * self.player.speed
+        item_image = tileset.ITEMS_TILE_SET.get_sprite_image(cfg.TRIFORCE_FRAME_ID)
         y_offset += 2
         item_pos = (self.player.rect.left, self.player.rect.top + y_offset)
         self.item_picked_up = Tile(item_pos, (self.visible_sprites,), item_image)
-        self.player.set_state(STATE_TRIFORCE)
+        self.player.set_state(cfg.STATE_TRIFORCE)
         self.triforce_sound.play()
 
     def continue_init(self):
         for text in self.text_sprites:
             text.kill()
-        if self.current_map == OVERWORLD_STARTING_MAP:
-            self.current_map = OVERWORLD_STARTING_MAP
-            self.current_map_screen = OVERWORLD_STARTING_SCREEN
-            self.create_map(OVERWORLD_STARTING_MAP + OVERWORLD_STARTING_SCREEN)
+        if self.current_map == cfg.OVERWORLD_STARTING_MAP:
+            self.current_map = cfg.OVERWORLD_STARTING_MAP
+            self.current_map_screen = cfg.OVERWORLD_STARTING_SCREEN
+            self.create_map(cfg.OVERWORLD_STARTING_MAP + cfg.OVERWORLD_STARTING_SCREEN)
             self.overworld_background_theme.play(loops=-1)
         else:
-            self.current_map = DUNGEON_STARTING_MAP
-            self.current_map_screen = DUNGEON_STARTING_SCREEN
-            self.create_map(DUNGEON_STARTING_MAP + DUNGEON_STARTING_SCREEN)
+            self.current_map = cfg.DUNGEON_STARTING_MAP
+            self.current_map_screen = cfg.DUNGEON_STARTING_SCREEN
+            self.create_map(cfg.DUNGEON_STARTING_MAP + cfg.DUNGEON_STARTING_SCREEN)
             self.dungeon_background_theme.play(loops=-1)
         self.player.revive(self.current_map)
         self.death_motion_index = 0
@@ -1230,7 +1235,7 @@ class Level(metaclass=Singleton):
                 # Reset attack cooldown timer until game is resumed
                 monster.attack_starting_time = pygame.time.get_ticks()
 
-        if self.item_picked_up is not None and PICKUP_PREFIX not in self.player.state:
+        if self.item_picked_up is not None and cfg.PICKUP_PREFIX not in self.player.state:
             self.item_picked_up.kill()
             self.item_picked_up = None
 
@@ -1269,10 +1274,11 @@ class Level(metaclass=Singleton):
         # Sprites are updated until map transitions
         if self.in_map_transition is None:
             if not self.in_menu:
-                if self.monsters_killed_in_the_room == self.enemies_spawned_in_the_room:
+                if (cfg.DUNGEON_PREFIX_LABEL in self.current_map
+                        and self.monsters_killed_in_the_room == self.enemies_spawned_in_the_room):
                     level_id = str(self.current_map) + str(self.current_map_screen)
-                    DUNGEON_DECIMATION[level_id] = True
-                    if(level_id in MONSTER_KILL_EVENT.keys()
+                    cfg.DUNGEON_DECIMATION[level_id] = True
+                    if(level_id in cfg.MONSTER_KILL_EVENT.keys()
                             and not self.dead_monsters_event_played):
                         self.map_kill_event_done()
                 self.visible_sprites.update()
@@ -1283,17 +1289,17 @@ class Level(metaclass=Singleton):
         # During map transition, all existing sprite is paused, not being updated until the transition is over
         else:
             # Warp makes a scrolling transition of the screen level
-            if MAP_TRANSITION_WARP in self.in_map_transition:
+            if cfg.MAP_TRANSITION_WARP in self.in_map_transition:
                 # Delete the cave stairs sprite when transitioning screen
                 for secret_bomb in self.secret_bomb_sprites:
                     secret_bomb.kill()
-                if self.map_scroll_animation_counter <= MAP_SCROLL_FRAMES_COUNT:
+                if self.map_scroll_animation_counter <= cfg.MAP_SCROLL_FRAMES_COUNT:
                     self.animate_map_transition()
                 else:
                     self.current_map_screen = self.next_map_screen
                     self.draw_floor()
                     self.create_map(self.current_map + str(self.current_map_screen))
-                    self.player.set_state(STATE_IDLE)
+                    self.player.set_state(cfg.STATE_IDLE)
                     self.player.set_position((self.player.warping_x, self.player.warping_y))
                     self.map_scroll_animation_counter = 0
                     self.in_map_transition = None
@@ -1301,10 +1307,10 @@ class Level(metaclass=Singleton):
             # Which, I know, is strange, but how the NES game operates from the player POV
             else:
                 # Wait for the stairs animation (and sound) to be over with, if any
-                if self.in_map_transition == MAP_TRANSITION_STAIRS:
+                if self.in_map_transition == cfg.MAP_TRANSITION_STAIRS:
                     current_time = pygame.time.get_ticks()
                     if current_time - self.stairs_animation_starting_time >= self.stairs_animation_duration:
-                        self.in_map_transition = MAP_TRANSITION_DONE
+                        self.in_map_transition = cfg.MAP_TRANSITION_DONE
 
                 # Generate new map's sprites (enemies, borders, ...), use appropriate music (if any), move the player
                 else:
@@ -1315,12 +1321,12 @@ class Level(metaclass=Singleton):
                     self.current_map = self.next_map
                     self.current_map_screen = self.next_map_screen
                     self.create_map(self.current_map + self.current_map_screen)
-                    if LEVEL_PREFIX_LABEL in self.current_map:
+                    if cfg.LEVEL_PREFIX_LABEL in self.current_map:
                         self.overworld_background_theme.play(loops=-1)
                     else:
                         self.overworld_background_theme.stop()
                     # Play dungeon music if in dungeon
-                    if DUNGEON_PREFIX_LABEL in self.current_map:
+                    if cfg.DUNGEON_PREFIX_LABEL in self.current_map:
                         self.dungeon_background_theme.play(loops=-1)
                     else:
                         self.dungeon_background_theme.stop()
@@ -1335,8 +1341,8 @@ class Level(metaclass=Singleton):
 
         if self.sys_text_surface is not None:
             sys_text_rect = self.sys_text_surface.get_rect()
-            x = (SCREEN_WIDTH - sys_text_rect.width) // 2
-            y = HUD_OFFSET + TILE_SIZE
+            x = (cfg.SCREEN_WIDTH - sys_text_rect.width) // 2
+            y = cfg.HUD_OFFSET + cfg.TILE_SIZE
             sys_text_rect.topleft = (x, y)
             pygame.draw.rect(self.display_surface, 'black', sys_text_rect)
             self.display_surface.blit(self.sys_text_surface, sys_text_rect)
@@ -1344,32 +1350,92 @@ class Level(metaclass=Singleton):
                 self.sys_text_surface = None
 
     def save(self):
-        try:
-            f = open("./save_file", "w")
-            save_content = (f'current_max_health:{self.player.current_max_health}\n'
-                            + f'health:{self.player.health}\n'
-                            + f'bombs:{self.player.bombs}\n'
-                            + f'keys:{self.player.keys}\n'
-                            + f'money:{self.player.money}\n'
-                            + f'has_boomerang:{self.player.has_boomerang}\n'
-                            + f'has_bombs:{self.player.has_bombs}\n'
-                            + f'has_candle:{self.player.has_candle}\n'
-                            + f'has_ladder:{self.player.has_ladder}\n'
-                            + f'has_wood_sword:{self.player.has_wood_sword}\n'
-                            + f'MAP_SECRETS_REVEALED:{MAP_SECRETS_REVEALED}\n'
-                            + f'MAP_ITEMS:{MAP_ITEMS}\n'
-                            + f'SHOPS:{SHOPS}\n'
-                            + f'MONSTER_KILL_EVENT:{MONSTER_KILL_EVENT}\n'
-                            + f'DUNGEON_DECIMATION:{DUNGEON_DECIMATION}\n'
-                            + f'DUNGEON_DOORS:{DUNGEON_DOORS}\n')
-            f.write(save_content)
-            f.close()
+        if (not self.in_menu
+                and not self.in_map_transition
+                and not self.player.isDead
+                and not self.player.is_winning):
+            try:
+                save_to_file(self.player)
+                font = pygame.font.Font(None, 30)
+                self.sys_text_surface = font.render(str('Saved successfully'), True, 'white')
+                self.sys_text_starting_time = pygame.time.get_ticks()
+            except OSError as error:
+                font = pygame.font.Font(None, 30)
+                self.sys_text_surface = font.render(str('Save Failed'), True, 'red')
+                self.sys_text_starting_time = pygame.time.get_ticks()
+                message = f"Couldn't save progress. An OSError has occurred. Arguments:\n{error.args}"
+                print(message, file=sys.stderr)
+        else:
             font = pygame.font.Font(None, 30)
-            self.sys_text_surface = font.render(str('Saved successfully'), True, 'white')
+            self.sys_text_surface = font.render(str("Can't save right now"), True, 'yellow')
             self.sys_text_starting_time = pygame.time.get_ticks()
-        except OSError as error:
+
+    def load(self):
+        if (not self.in_menu
+                and not self.in_map_transition
+                and not self.player.isDead
+                and not self.player.is_winning):
+            try:
+                load_from_save_file(self.player)
+                self.reload_level()
+
+                font = pygame.font.Font(None, 30)
+                self.sys_text_surface = font.render(str('Loaded save successfully'), True, 'white')
+                self.sys_text_starting_time = pygame.time.get_ticks()
+            except OSError as error:
+                font = pygame.font.Font(None, 30)
+                self.sys_text_surface = font.render(str('Load Failed'), True, 'red')
+                self.sys_text_starting_time = pygame.time.get_ticks()
+                message = f"Couldn't save progress. An OSError has occurred. Arguments:\n{error.args}"
+                print(message, file=sys.stderr)
+        else:
             font = pygame.font.Font(None, 30)
-            self.sys_text_surface = font.render(str('Save Failed'), True, 'red')
+            self.sys_text_surface = font.render(str("Can't load right now"), True, 'yellow')
             self.sys_text_starting_time = pygame.time.get_ticks()
-            message = f"Couldn't save progress. An OSError has occurred. Arguments:\n{error.args}"
-            print(message, file=sys.stderr)
+
+    def reload_level(self):
+        # Kill everything
+        for warp in self.warp_sprites:
+            warp.kill()
+        for secret_flame in self.secret_flame_sprites:
+            secret_flame.kill()
+        for enemy in self.enemy_sprites:
+            enemy.kill()
+        for particle in self.particle_sprites:
+            particle.kill()
+        for obstacle in self.obstacle_sprites:
+            obstacle.kill()
+        for item in self.lootable_items_sprites:
+            item.kill()
+        for npc in self.npc_sprites:
+            npc.kill()
+        for purchasable in self.purchasable_sprites:
+            purchasable.kill()
+        for text in self.text_sprites:
+            text.kill()
+        for door in self.door_sprites:
+            door.kill()
+
+        # Stop all music
+        self.overworld_background_theme.stop()
+        self.dungeon_background_theme.stop()
+
+        self.in_menu = False
+        self.player.reload_player()
+        self.current_map = cfg.STARTING_MAP
+        self.current_map_screen = cfg.STARTING_SCREEN
+        if self.current_map == cfg.OVERWORLD_STARTING_MAP:
+            self.player.set_position(cfg.OVERWORLD_PLAYER_START_POS)
+            self.overworld_background_theme.play(loops=-1)
+        else:
+            self.player.set_position(cfg.DUNGEON_PLAYER_START_POS)
+            self.dungeon_background_theme.play(loops=-1)
+        self.create_map(self.current_map + self.current_map_screen)
+        self.in_map_transition = None
+        self.map_scroll_animation_counter = 0
+        self.next_map = None
+        self.next_map_screen = None
+        self.player_new_position = None
+        self.enemies_spawned_in_the_room = 0
+        self.monsters_killed_in_the_room = 0
+        self.dead_monsters_event_played = False

--- a/code/level.py
+++ b/code/level.py
@@ -1345,7 +1345,7 @@ class Level(metaclass=Singleton):
 
     def save(self):
         try:
-            f = open("../save/save", "w")
+            f = open("./save_file", "w")
             save_content = (f'current_max_health:{self.player.current_max_health}\n'
                             + f'health:{self.player.health}\n'
                             + f'bombs:{self.player.bombs}\n'

--- a/code/main.py
+++ b/code/main.py
@@ -2,6 +2,7 @@ import pygame
 import sys
 from settings import *
 import tileset
+import inputs
 from level import Level
 
 
@@ -39,9 +40,9 @@ class Game:
                 if event.type == pygame.KEYDOWN:
                     keys_pressed.append(event.key)
                 if event.type == pygame.KEYUP:
+                    if event.key == inputs.SAVE_KEY:
+                        Level().save()
                     keys_pressed.remove(event.key)
-            if pygame.K_F5 in keys_pressed:
-                Level().save()
             Level().handle_input(keys_pressed)
 
 

--- a/code/main.py
+++ b/code/main.py
@@ -40,6 +40,8 @@ class Game:
                     keys_pressed.append(event.key)
                 if event.type == pygame.KEYUP:
                     keys_pressed.remove(event.key)
+            if pygame.K_F5 in keys_pressed:
+                Level().save()
             Level().handle_input(keys_pressed)
 
 

--- a/code/main.py
+++ b/code/main.py
@@ -1,6 +1,6 @@
 import pygame
 import sys
-from settings import *
+import settings as cfg
 import tileset
 import inputs
 from level import Level
@@ -10,28 +10,28 @@ class Game:
     def __init__(self):
         # general setup
         pygame.init()
-        self.screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
-        pygame.display.set_caption(GAME_NAME)
+        self.screen = pygame.display.set_mode((cfg.SCREEN_WIDTH, cfg.SCREEN_HEIGHT))
+        pygame.display.set_caption(cfg.GAME_NAME)
         self.clock = pygame.time.Clock()
-        tileset.CONSUMABLES_TILE_SET = tileset.TileSet(TILE_CONSUMABLES)
-        tileset.DOORS_TILE_SET = tileset.TileSet(TILE_DOORS)
-        tileset.ENEMIES_TILE_SET = tileset.TileSet(TILE_ENEMIES)
-        tileset.FONT_TILE_SET = tileset.TileSet(TILE_FONTS)
-        tileset.HUD_TILE_SET = tileset.TileSet(TILE_HUD)
-        tileset.ITEMS_TILE_SET = tileset.TileSet(TILE_ITEMS)
-        tileset.LEVELS_TILE_SET = tileset.TileSet(TILE_LEVELS)
-        tileset.NPCS_TILE_SET = tileset.TileSet(TILE_NPCS)
-        tileset.PARTICLES_TILE_SET = tileset.TileSet(TILE_PARTICLES)
-        tileset.PLAYER_TILE_SET = tileset.TileSet(TILE_PLAYER)
-        tileset.WARPS_TILE_SET = tileset.TileSet(TILE_WARPS)
+        tileset.CONSUMABLES_TILE_SET = tileset.TileSet(cfg.TILE_CONSUMABLES)
+        tileset.DOORS_TILE_SET = tileset.TileSet(cfg.TILE_DOORS)
+        tileset.ENEMIES_TILE_SET = tileset.TileSet(cfg.TILE_ENEMIES)
+        tileset.FONT_TILE_SET = tileset.TileSet(cfg.TILE_FONTS)
+        tileset.HUD_TILE_SET = tileset.TileSet(cfg.TILE_HUD)
+        tileset.ITEMS_TILE_SET = tileset.TileSet(cfg.TILE_ITEMS)
+        tileset.LEVELS_TILE_SET = tileset.TileSet(cfg.TILE_LEVELS)
+        tileset.NPCS_TILE_SET = tileset.TileSet(cfg.TILE_NPCS)
+        tileset.PARTICLES_TILE_SET = tileset.TileSet(cfg.TILE_PARTICLES)
+        tileset.PLAYER_TILE_SET = tileset.TileSet(cfg.TILE_PLAYER)
+        tileset.WARPS_TILE_SET = tileset.TileSet(cfg.TILE_WARPS)
 
     def run(self):
         keys_pressed = []
         while True:
-            self.screen.fill(BLACK_LABEL)
+            self.screen.fill(cfg.BLACK_LABEL)
             Level().run()
             pygame.display.update()
-            self.clock.tick(FPS)
+            self.clock.tick(cfg.FPS)
 
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
@@ -42,6 +42,8 @@ class Game:
                 if event.type == pygame.KEYUP:
                     if event.key == inputs.SAVE_KEY:
                         Level().save()
+                    if event.key == inputs.LOAD_KEY:
+                        Level().load()
                     keys_pressed.remove(event.key)
             Level().handle_input(keys_pressed)
 

--- a/code/particles.py
+++ b/code/particles.py
@@ -3,7 +3,7 @@ import random
 import tileset
 import pygame
 import level as game
-from settings import *
+import settings as cfg
 from abc import ABC
 
 
@@ -43,7 +43,7 @@ class Particle(pygame.sprite.Sprite, ABC):
     @abc.abstractmethod
     def load_animation_frames(self, tile_set):
         for i in range(self.nb_frames):
-            tiles_offset = SPRITE_SIZE // TILE_SIZE * i
+            tiles_offset = cfg.SPRITE_SIZE // cfg.TILE_SIZE * i
             self.move_animations.append(tile_set.get_sprite_image(self.frame_id + tiles_offset))
 
     @abc.abstractmethod
@@ -93,22 +93,22 @@ class PWoodenSword(Particle):
         self.particle_sprites = particle_sprites
 
         self.direction_label = owner_direction_label
-        if owner_direction_label == UP_LABEL:
+        if owner_direction_label == cfg.UP_LABEL:
             self.pos_x += 6
             self.pos_y -= 22
             self.direction_vector.x = 0
             self.direction_vector.y = -1
-        elif owner_direction_label == RIGHT_LABEL:
+        elif owner_direction_label == cfg.RIGHT_LABEL:
             self.pos_x += 20
             self.pos_y += 2
             self.direction_vector.x = 1
             self.direction_vector.y = 0
-        elif owner_direction_label == DOWN_LABEL:
+        elif owner_direction_label == cfg.DOWN_LABEL:
             self.pos_x += 14
             self.pos_y += 22
             self.direction_vector.x = 0
             self.direction_vector.y = 1
-        elif owner_direction_label == LEFT_LABEL:
+        elif owner_direction_label == cfg.LEFT_LABEL:
             self.pos_x -= 20
             self.pos_y += 2
             self.direction_vector.x = -1
@@ -116,21 +116,21 @@ class PWoodenSword(Particle):
 
         self.move_animation_cooldown = 5
         self.move_animations = {
-            UP_LABEL: [],
-            RIGHT_LABEL: [],
-            DOWN_LABEL: [],
-            LEFT_LABEL: []
+            cfg.UP_LABEL: [],
+            cfg.RIGHT_LABEL: [],
+            cfg.DOWN_LABEL: [],
+            cfg.LEFT_LABEL: []
         }
 
-        self.frame_id = WOOD_SWORD_RIGHT_FRAME_ID
-        self.nb_frames = WOOD_SWORD_ATTACK_FRAMES
+        self.frame_id = cfg.WOOD_SWORD_RIGHT_FRAME_ID
+        self.nb_frames = cfg.WOOD_SWORD_ATTACK_FRAMES
         self.load_animation_frames(tileset.PARTICLES_TILE_SET)
         
         self.image = self.move_animations[self.direction_label][0]
         self.rect = self.image.get_rect(topleft=(self.pos_x, self.pos_y))
         # Hitbox will stay at full sword length despite the animation, because it is extremely fast and doesn't really
         # improve gameplay at all.
-        if owner_direction_label == UP_LABEL or owner_direction_label == DOWN_LABEL:
+        if owner_direction_label == cfg.UP_LABEL or owner_direction_label == cfg.DOWN_LABEL:
             self.hitbox = self.rect.inflate(-26, 0)
             self.hitbox.left = self.rect.left + 4
             self.hitbox.top = self.rect.top
@@ -140,9 +140,9 @@ class PWoodenSword(Particle):
             self.hitbox.top = self.rect.top + 14
 
         self.affects_enemy = True
-        self.collision_damage = WOOD_SWORD_DMG
+        self.collision_damage = cfg.WOOD_SWORD_DMG
 
-        self.sword_attack_sound = pygame.mixer.Sound(SOUND_SWORD_ATTACK)
+        self.sword_attack_sound = pygame.mixer.Sound(cfg.SOUND_SWORD_ATTACK)
         self.sword_attack_sound.set_volume(0.5)
         self.sword_attack_sound.play()
 
@@ -150,14 +150,14 @@ class PWoodenSword(Particle):
 
     def load_animation_frames(self, particle_tile_set):
         for i in range(self.nb_frames):
-            tiles_offset = SPRITE_SIZE // TILE_SIZE * i
-            self.move_animations[UP_LABEL].append(particle_tile_set.get_sprite_image(
-                WOOD_SWORD_UP_FRAME_ID + tiles_offset))
-            self.move_animations[RIGHT_LABEL].append(particle_tile_set.get_sprite_image(
-                WOOD_SWORD_RIGHT_FRAME_ID + tiles_offset))
-            self.move_animations[DOWN_LABEL].append(particle_tile_set.get_sprite_image(
-                WOOD_SWORD_DOWN_FRAME_ID + tiles_offset))
-            self.move_animations[LEFT_LABEL].append(
+            tiles_offset = cfg.SPRITE_SIZE // cfg.TILE_SIZE * i
+            self.move_animations[cfg.UP_LABEL].append(particle_tile_set.get_sprite_image(
+                cfg.WOOD_SWORD_UP_FRAME_ID + tiles_offset))
+            self.move_animations[cfg.RIGHT_LABEL].append(particle_tile_set.get_sprite_image(
+                cfg.WOOD_SWORD_RIGHT_FRAME_ID + tiles_offset))
+            self.move_animations[cfg.DOWN_LABEL].append(particle_tile_set.get_sprite_image(
+                cfg.WOOD_SWORD_DOWN_FRAME_ID + tiles_offset))
+            self.move_animations[cfg.LEFT_LABEL].append(
                 pygame.transform.flip(
                     particle_tile_set.get_sprite_image(self.frame_id + tiles_offset),
                     True,
@@ -177,14 +177,14 @@ class PWoodenSword(Particle):
         # Collision with a monster
         for enemy in self.enemy_sprites:
             if isinstance(enemy, game.Darknut):
-                if (enemy.state != STATE_STUN
-                        and STATE_HURT not in enemy.state
+                if (enemy.state != cfg.STATE_STUN
+                        and cfg.STATE_HURT not in enemy.state
                         and enemy.shield_hitbox.colliderect(self.hitbox)
                         and self.collision_damage > 0):
                     self.collision_damage = 0
                     enemy.shield_block_sound.play()
                 elif (enemy.hitbox.colliderect(self.hitbox)
-                      and STATE_HURT not in enemy.state):
+                      and cfg.STATE_HURT not in enemy.state):
                     enemy.take_damage(self.collision_damage, self.direction_label)
             else:
                 if enemy.hitbox.colliderect(self.hitbox):
@@ -231,23 +231,23 @@ class PBoomerang(Particle):
         self.monster_variant = monster_variant
 
         if self.direction_vector.x == 0 and self.direction_vector.y == 0:
-            if owner_direction_label == UP_LABEL:
+            if owner_direction_label == cfg.UP_LABEL:
                 self.direction_vector.x = 0
                 self.direction_vector.y = -1
-            elif owner_direction_label == RIGHT_LABEL:
+            elif owner_direction_label == cfg.RIGHT_LABEL:
                 self.direction_vector.x = 1
                 self.direction_vector.y = 0
-            elif owner_direction_label == DOWN_LABEL:
+            elif owner_direction_label == cfg.DOWN_LABEL:
                 self.direction_vector.x = 0
                 self.direction_vector.y = 1
-            elif owner_direction_label == LEFT_LABEL:
+            elif owner_direction_label == cfg.LEFT_LABEL:
                 self.direction_vector.x = -1
                 self.direction_vector.y = 0
 
         self.move_animation_cooldown = 100
 
-        self.frame_id = BOOMERANG_FRAME_ID
-        self.nb_frames = BOOMERANG_FRAMES
+        self.frame_id = cfg.BOOMERANG_FRAME_ID
+        self.nb_frames = cfg.BOOMERANG_FRAMES
         self.load_animation_frames(tileset.ITEMS_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -258,16 +258,16 @@ class PBoomerang(Particle):
 
         if self.monster_variant:
             self.affects_player = True
-            self.collision_damage = PLAYER_HEALTH_PER_HEART
-            self.speed = BOOMERANG_SPEED
+            self.collision_damage = cfg.PLAYER_HEALTH_PER_HEART
+            self.speed = cfg.BOOMERANG_SPEED
             self.boomerang_starting_time = pygame.time.get_ticks()
             self.boomerang_go_back_cooldown = self.owner_ref.boomerang_timerange
         else:
             self.affects_enemy = True
-            self.collision_damage = BOOMERANG_DMG
-            self.speed = BOOMERANG_SPEED
+            self.collision_damage = cfg.BOOMERANG_DMG
+            self.speed = cfg.BOOMERANG_SPEED
 
-        self.boomerang_attack_sound = pygame.mixer.Sound(SOUND_BOOMERANG_ATTACK)
+        self.boomerang_attack_sound = pygame.mixer.Sound(cfg.SOUND_BOOMERANG_ATTACK)
         self.boomerang_attack_sound.set_volume(0.5)
         self.boomerang_attack_sound.play(loops=-1)
 
@@ -362,32 +362,32 @@ class Rock(Particle):
 
         self.obstacle_sprites = obstacle_sprites
 
-        if owner_direction_label == UP_LABEL:
+        if owner_direction_label == cfg.UP_LABEL:
             self.direction_vector.x = 0
             self.direction_vector.y = -1
-        elif owner_direction_label == RIGHT_LABEL:
+        elif owner_direction_label == cfg.RIGHT_LABEL:
             self.direction_vector.x = 1
             self.direction_vector.y = 0
-        elif owner_direction_label == DOWN_LABEL:
+        elif owner_direction_label == cfg.DOWN_LABEL:
             self.direction_vector.x = 0
             self.direction_vector.y = 1
-        elif owner_direction_label == LEFT_LABEL:
+        elif owner_direction_label == cfg.LEFT_LABEL:
             self.direction_vector.x = -1
             self.direction_vector.y = 0
 
-        self.frame_id = ROCK_FRAME_ID
-        self.nb_frames = ROCK_FRAMES
+        self.frame_id = cfg.ROCK_FRAME_ID
+        self.nb_frames = cfg.ROCK_FRAMES
         self.load_animation_frames(tileset.PARTICLES_TILE_SET)
 
         self.image = self.move_animations[0]
-        self.rect = self.image.get_rect(topleft=(self.pos_x + TILE_SIZE//2, self.pos_y + 2))
+        self.rect = self.image.get_rect(topleft=(self.pos_x + cfg.TILE_SIZE//2, self.pos_y + 2))
         self.hitbox = self.rect.inflate(-16, -12)
         self.hitbox.left = self.rect.left
         self.hitbox.top = self.rect.top + 4
 
         self.affects_player = True
-        self.collision_damage = ROCK_DMG
-        self.speed = ROCK_SPEED
+        self.collision_damage = cfg.ROCK_DMG
+        self.speed = cfg.ROCK_SPEED
 
         self.is_active = True
 
@@ -401,9 +401,9 @@ class Rock(Particle):
     def collision(self, direction):
         for sprite in self.obstacle_sprites:
             if (sprite.hitbox.colliderect(self.hitbox)
-                    and sprite.type != LIMIT_WATER_INDEX
-                    and sprite.type != LIMIT_LADDER_INDEX
-                    and sprite.type != LIMIT_LAKE_BORDER_INDEX):
+                    and sprite.type != cfg.LIMIT_WATER_INDEX
+                    and sprite.type != cfg.LIMIT_LADDER_INDEX
+                    and sprite.type != cfg.LIMIT_LAKE_BORDER_INDEX):
                 self.kill()
 
     def move(self):
@@ -431,56 +431,56 @@ class Arrow(Particle):
 
         self.obstacle_sprites = obstacle_sprites
 
-        if owner_direction_label == UP_LABEL:
+        if owner_direction_label == cfg.UP_LABEL:
             self.direction_vector.x = 0
             self.direction_vector.y = -1
-        elif owner_direction_label == RIGHT_LABEL:
+        elif owner_direction_label == cfg.RIGHT_LABEL:
             self.direction_vector.x = 1
             self.direction_vector.y = 0
-        elif owner_direction_label == DOWN_LABEL:
+        elif owner_direction_label == cfg.DOWN_LABEL:
             self.direction_vector.x = 0
             self.direction_vector.y = 1
-        elif owner_direction_label == LEFT_LABEL:
+        elif owner_direction_label == cfg.LEFT_LABEL:
             self.direction_vector.x = -1
             self.direction_vector.y = 0
 
-        self.frame_up_id = ARROW_FRAME_UP_ID
-        self.frame_right_id = ARROW_FRAME_RIGHT_ID
-        self.nb_frames = ARROW_FRAMES
+        self.frame_up_id = cfg.ARROW_FRAME_UP_ID
+        self.frame_right_id = cfg.ARROW_FRAME_RIGHT_ID
+        self.nb_frames = cfg.ARROW_FRAMES
 
         self.move_animations = {
-            UP_LABEL: [],
-            RIGHT_LABEL: [],
-            DOWN_LABEL: [],
-            LEFT_LABEL: []
+            cfg.UP_LABEL: [],
+            cfg.RIGHT_LABEL: [],
+            cfg.DOWN_LABEL: [],
+            cfg.LEFT_LABEL: []
         }
         self.load_animation_frames(tileset.PARTICLES_TILE_SET)
 
         self.image = self.move_animations[owner_direction_label][0]
-        self.rect = self.image.get_rect(topleft=(self.pos_x + TILE_SIZE//2, self.pos_y))
+        self.rect = self.image.get_rect(topleft=(self.pos_x + cfg.TILE_SIZE//2, self.pos_y))
         self.hitbox = self.rect.inflate(-16, -12)
         self.hitbox.left = self.rect.left
         self.hitbox.top = self.rect.top + 4
 
         self.affects_player = True
-        self.collision_damage = ARROW_DMG
-        self.speed = ARROW_SPEED
+        self.collision_damage = cfg.ARROW_DMG
+        self.speed = cfg.ARROW_SPEED
 
         self.is_active = True
 
     def load_animation_frames(self, particle_tile_set):
         for i in range(self.nb_frames):
-            tiles_offset = SPRITE_SIZE // TILE_SIZE * i
-            self.move_animations[UP_LABEL].append(
+            tiles_offset = cfg.SPRITE_SIZE // cfg.TILE_SIZE * i
+            self.move_animations[cfg.UP_LABEL].append(
                 particle_tile_set.get_sprite_image(self.frame_up_id + tiles_offset))
-            self.move_animations[DOWN_LABEL].append(
+            self.move_animations[cfg.DOWN_LABEL].append(
                 pygame.transform.flip(
                     particle_tile_set.get_sprite_image(self.frame_up_id + tiles_offset),
                     False,
                     True))
-            self.move_animations[RIGHT_LABEL].append(
+            self.move_animations[cfg.RIGHT_LABEL].append(
                 particle_tile_set.get_sprite_image(self.frame_right_id + tiles_offset))
-            self.move_animations[LEFT_LABEL].append(
+            self.move_animations[cfg.LEFT_LABEL].append(
                 pygame.transform.flip(
                     particle_tile_set.get_sprite_image(self.frame_right_id + tiles_offset),
                     True,
@@ -493,10 +493,10 @@ class Arrow(Particle):
     def collision(self, direction):
         for sprite in self.obstacle_sprites:
             if (sprite.hitbox.colliderect(self.hitbox)
-                    and sprite.type != LIMIT_TREE_INDEX
-                    and sprite.type != LIMIT_WATER_INDEX
-                    and sprite.type != LIMIT_LADDER_INDEX
-                    and sprite.type != LIMIT_LAKE_BORDER_INDEX):
+                    and sprite.type != cfg.LIMIT_TREE_INDEX
+                    and sprite.type != cfg.LIMIT_WATER_INDEX
+                    and sprite.type != cfg.LIMIT_LADDER_INDEX
+                    and sprite.type != cfg.LIMIT_LAKE_BORDER_INDEX):
                 self.kill()
 
     def move(self):
@@ -519,14 +519,14 @@ class MagicMissile(Particle):
                  owner_direction_vector,
                  groups,
                  obstacle_sprites,
-                 dmg=MAGIC_MISSILE_DMG,
+                 dmg=cfg.MAGIC_MISSILE_DMG,
                  aim_at_player=True):
         super().__init__(owner_pos, owner_direction_vector, groups)
 
         self.obstacle_sprites = obstacle_sprites
 
-        self.frame_id = MAGIC_MISSILE_FRAME_ID
-        self.nb_frames = MAGIC_MISSILE_FRAMES
+        self.frame_id = cfg.MAGIC_MISSILE_FRAME_ID
+        self.nb_frames = cfg.MAGIC_MISSILE_FRAMES
 
         self.move_animations = []
         self.move_animation_cooldown = 100
@@ -550,13 +550,13 @@ class MagicMissile(Particle):
         self.affects_player = True
         self.bypasses_shield = True
         self.collision_damage = dmg
-        self.speed = MAGIC_MISSILE_SPEED
+        self.speed = cfg.MAGIC_MISSILE_SPEED
 
         self.is_active = True
 
     def load_animation_frames(self, particle_tile_set):
         for i in range(self.nb_frames):
-            tiles_offset = SPRITE_SIZE // TILE_SIZE * i
+            tiles_offset = cfg.SPRITE_SIZE // cfg.TILE_SIZE * i
             self.move_animations.append(
                 particle_tile_set.get_sprite_image(self.frame_id + tiles_offset))
 
@@ -566,10 +566,10 @@ class MagicMissile(Particle):
     def collision(self, direction):
         for sprite in self.obstacle_sprites:
             if (sprite.hitbox.colliderect(self.hitbox)
-                    and sprite.type != LIMIT_TREE_INDEX
-                    and sprite.type != LIMIT_WATER_INDEX
-                    and sprite.type != LIMIT_LADDER_INDEX
-                    and sprite.type != LIMIT_LAKE_BORDER_INDEX):
+                    and sprite.type != cfg.LIMIT_TREE_INDEX
+                    and sprite.type != cfg.LIMIT_WATER_INDEX
+                    and sprite.type != cfg.LIMIT_LADDER_INDEX
+                    and sprite.type != cfg.LIMIT_LAKE_BORDER_INDEX):
                 self.kill()
 
     def move(self):
@@ -594,8 +594,8 @@ class Heart(Particle):
 
         self.dropped_by_event = dropped_by_event
 
-        self.frame_id = HEART_FRAME_ID
-        self.nb_frames = HEART_FRAMES
+        self.frame_id = cfg.HEART_FRAME_ID
+        self.nb_frames = cfg.HEART_FRAMES
         self.load_animation_frames(tileset.CONSUMABLES_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -606,7 +606,7 @@ class Heart(Particle):
         self.bypasses_shield = True
         self.collision_damage = 0
 
-        self.heart_pickup_sound = pygame.mixer.Sound(SOUND_TINY_PICKUP)
+        self.heart_pickup_sound = pygame.mixer.Sound(cfg.SOUND_TINY_PICKUP)
         self.heart_pickup_sound.set_volume(0.3)
 
         self.is_active = True
@@ -629,9 +629,9 @@ class Heart(Particle):
     def effect(self):
         if self.dropped_by_event:
             level_id = str(game.Level().current_map) + str(game.Level().current_map_screen)
-            MONSTER_KILL_EVENT.pop(level_id)
+            cfg.MONSTER_KILL_EVENT.pop(level_id)
         self.heart_pickup_sound.play()
-        game.Level().player_pick_up(HEART_LABEL, 1)
+        game.Level().player_pick_up(cfg.HEART_LABEL, 1)
 
     def update(self):
         super().update()
@@ -646,8 +646,8 @@ class Rupee(Particle):
         self.amount = amount
         self.dropped_by_event = dropped_by_event
 
-        self.frame_id = RUPEE_FRAME_ID
-        self.nb_frames = RUPEE_FRAMES
+        self.frame_id = cfg.RUPEE_FRAME_ID
+        self.nb_frames = cfg.RUPEE_FRAMES
         self.load_animation_frames(tileset.CONSUMABLES_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -678,8 +678,8 @@ class Rupee(Particle):
     def effect(self):
         if self.dropped_by_event:
             level_id = str(game.Level().current_map) + str(game.Level().current_map_screen)
-            MONSTER_KILL_EVENT.pop(level_id)
-        game.Level().player_pick_up(RUPEE_LABEL, self.amount)
+            cfg.MONSTER_KILL_EVENT.pop(level_id)
+        game.Level().player_pick_up(cfg.RUPEE_LABEL, self.amount)
 
     def update(self):
         super().update()
@@ -693,8 +693,8 @@ class CBomb(Particle):
 
         self.dropped_by_event = dropped_by_event
 
-        self.frame_id = CBOMB_FRAME_ID
-        self.nb_frames = CBOMB_FRAMES
+        self.frame_id = cfg.CBOMB_FRAME_ID
+        self.nb_frames = cfg.CBOMB_FRAMES
         self.load_animation_frames(tileset.CONSUMABLES_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -705,7 +705,7 @@ class CBomb(Particle):
         self.bypasses_shield = True
         self.collision_damage = 0
 
-        self.bomb_pickup_sound = pygame.mixer.Sound(SOUND_SMALL_PICKUP)
+        self.bomb_pickup_sound = pygame.mixer.Sound(cfg.SOUND_SMALL_PICKUP)
         self.bomb_pickup_sound.set_volume(0.3)
 
         self.is_active = True
@@ -729,9 +729,9 @@ class CBomb(Particle):
     def effect(self):
         if self.dropped_by_event:
             level_id = str(game.Level().current_map) + str(game.Level().current_map_screen)
-            MONSTER_KILL_EVENT.pop(level_id)
+            cfg.MONSTER_KILL_EVENT.pop(level_id)
         self.bomb_pickup_sound.play()
-        game.Level().player_pick_up(BOMB_LABEL, PLAYER_BOMB_LOOT_AMOUNT)
+        game.Level().player_pick_up(cfg.BOMB_LABEL, cfg.PLAYER_BOMB_LOOT_AMOUNT)
 
     def update(self):
         super().update()
@@ -745,8 +745,8 @@ class Fairy(Particle):
 
         self.obstacle_sprites = obstacle_sprites
 
-        self.frame_id = FAIRY_FRAMES_ID
-        self.nb_frames = FAIRY_FRAMES
+        self.frame_id = cfg.FAIRY_FRAMES_ID
+        self.nb_frames = cfg.FAIRY_FRAMES
         self.load_animation_frames(tileset.CONSUMABLES_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -756,12 +756,12 @@ class Fairy(Particle):
         self.affects_player = True
         self.bypasses_shield = True
         self.collision_damage = 0
-        self.speed = FAIRY_SPEED
+        self.speed = cfg.FAIRY_SPEED
 
         self.direction_starting_time = 0
         self.direction_cooldown = random.randrange(500, 2000, 100)
 
-        self.fairy_pickup_sound = pygame.mixer.Sound(SOUND_SMALL_PICKUP)
+        self.fairy_pickup_sound = pygame.mixer.Sound(cfg.SOUND_SMALL_PICKUP)
         self.fairy_pickup_sound.set_volume(0.3)
 
         self.is_active = True
@@ -775,7 +775,7 @@ class Fairy(Particle):
     def collision(self, direction):
         # This flies, so it will only collide with screen border obstacles, that are given in obstacles_sprites
         # Be careful when creating a fairy !
-        if direction == HORIZONTAL_LABEL:
+        if direction == cfg.HORIZONTAL_LABEL:
             for sprite in self.obstacle_sprites:
                 if sprite.hitbox.colliderect(self.hitbox):
                     if self.direction_vector.x > 0:
@@ -783,7 +783,7 @@ class Fairy(Particle):
                     if self.direction_vector.x < 0:
                         self.hitbox.left = sprite.hitbox.right
 
-        elif direction == VERTICAL_LABEL:
+        elif direction == cfg.VERTICAL_LABEL:
             for sprite in self.obstacle_sprites:
                 if sprite.hitbox.colliderect(self.hitbox):
                     if self.direction_vector.y > 0:
@@ -804,15 +804,15 @@ class Fairy(Particle):
                 self.direction_vector = self.direction_vector.normalize()
 
         self.hitbox.x += self.direction_vector.x * self.speed
-        self.collision(HORIZONTAL_LABEL)
+        self.collision(cfg.HORIZONTAL_LABEL)
         self.hitbox.y += self.direction_vector.y * self.speed
-        self.collision(VERTICAL_LABEL)
+        self.collision(cfg.VERTICAL_LABEL)
 
         self.rect.center = self.hitbox.center
 
     def effect(self):
         self.fairy_pickup_sound.play()
-        game.Level().player_pick_up(FAIRY_LABEL, PLAYER_HEALTH_MAX)
+        game.Level().player_pick_up(cfg.FAIRY_LABEL, cfg.PLAYER_HEALTH_MAX)
 
     def update(self):
         super().update()
@@ -827,8 +827,8 @@ class Key(Particle):
         self.level_id = level_id
         self.dropped_by_event = dropped_by_event
 
-        self.frame_id = KEY_FRAME_ID
-        self.nb_frames = KEY_FRAMES
+        self.frame_id = cfg.KEY_FRAME_ID
+        self.nb_frames = cfg.KEY_FRAMES
         self.load_animation_frames(tileset.CONSUMABLES_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -860,10 +860,10 @@ class Key(Particle):
     def effect(self):
         if self.dropped_by_event:
             level_id = str(game.Level().current_map) + str(game.Level().current_map_screen)
-            MONSTER_KILL_EVENT.pop(level_id)
+            cfg.MONSTER_KILL_EVENT.pop(level_id)
         else:
-            MAP_ITEMS[self.level_id][KEY_LABEL] = False
-        game.Level().player_pick_up(KEY_LABEL, 1)
+            cfg.MAP_ITEMS[self.level_id][cfg.KEY_LABEL] = False
+        game.Level().player_pick_up(cfg.KEY_LABEL, 1)
 
     def update(self):
         super().update()
@@ -882,28 +882,28 @@ class Bomb(Particle):
         self.owner_pos = owner_pos
         self.groups = groups
 
-        self.frame_id = PBOMB_FRAME_ID
-        self.nb_frames = PBOMB_FRAMES
+        self.frame_id = cfg.PBOMB_FRAME_ID
+        self.nb_frames = cfg.PBOMB_FRAMES
         self.load_animation_frames(tileset.PARTICLES_TILE_SET)
 
         self.collision_damage = 0
 
-        self.bomb_drop_sound = pygame.mixer.Sound(SOUND_BOMB_DROP)
+        self.bomb_drop_sound = pygame.mixer.Sound(cfg.SOUND_BOMB_DROP)
         self.bomb_drop_sound.set_volume(0.3)
         self.bomb_drop_sound.play()
-        self.bomb_explode_sound = pygame.mixer.Sound(SOUND_BOMB_EXPLODE)
+        self.bomb_explode_sound = pygame.mixer.Sound(cfg.SOUND_BOMB_EXPLODE)
         self.bomb_explode_sound.set_volume(0.3)
 
-        if owner_direction_label == UP_LABEL:
+        if owner_direction_label == cfg.UP_LABEL:
             self.pos_x = owner_pos[0]
             self.pos_y = owner_pos[1] - 32
-        elif owner_direction_label == RIGHT_LABEL:
+        elif owner_direction_label == cfg.RIGHT_LABEL:
             self.pos_x = owner_pos[0] + 24
             self.pos_y = owner_pos[1]
-        elif owner_direction_label == DOWN_LABEL:
+        elif owner_direction_label == cfg.DOWN_LABEL:
             self.pos_x = owner_pos[0]
             self.pos_y = owner_pos[1] + 32
-        elif owner_direction_label == LEFT_LABEL:
+        elif owner_direction_label == cfg.LEFT_LABEL:
             self.pos_x = owner_pos[0] - 24
             self.pos_y = owner_pos[1]
         self.image = self.move_animations[0]
@@ -955,8 +955,8 @@ class BombSmoke(Particle):
         owner_direction_vector = pygame.math.Vector2()
         super().__init__(effect_pos, owner_direction_vector, groups)
 
-        self.frame_id = PBOMB_SMOKE_FRAME_ID
-        self.nb_frames = PBOMB_SMOKE_FRAMES
+        self.frame_id = cfg.PBOMB_SMOKE_FRAME_ID
+        self.nb_frames = cfg.PBOMB_SMOKE_FRAMES
         self.load_animation_frames(tileset.PARTICLES_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -969,7 +969,7 @@ class BombSmoke(Particle):
 
         self.smoke_starting_time = self.move_animation_timer_start
         self.move_animation_cooldown = 150
-        self.smoke_cooldown = PBOMB_SMOKE_FRAMES * self.move_animation_cooldown
+        self.smoke_cooldown = cfg.PBOMB_SMOKE_FRAMES * self.move_animation_cooldown
 
     def load_animation_frames(self, particle_tile_set):
         super().load_animation_frames(particle_tile_set)
@@ -1009,34 +1009,34 @@ class Flame(Particle):
         self.player_ref = player
 
         self.direction_label = owner_direction_label
-        if owner_direction_label == UP_LABEL:
+        if owner_direction_label == cfg.UP_LABEL:
             self.direction_vector.x = 0
             self.direction_vector.y = -1
             self.pos_x = owner_pos[0]
-            self.pos_y = owner_pos[1] - TILE_SIZE
-        elif owner_direction_label == RIGHT_LABEL:
+            self.pos_y = owner_pos[1] - cfg.TILE_SIZE
+        elif owner_direction_label == cfg.RIGHT_LABEL:
             self.direction_vector.x = 1
             self.direction_vector.y = 0
-            self.pos_x = owner_pos[0] + TILE_SIZE
+            self.pos_x = owner_pos[0] + cfg.TILE_SIZE
             self.pos_y = owner_pos[1]
-        elif owner_direction_label == DOWN_LABEL:
+        elif owner_direction_label == cfg.DOWN_LABEL:
             self.direction_vector.x = 0
             self.direction_vector.y = 1
             self.pos_x = owner_pos[0]
-            self.pos_y = owner_pos[1] + TILE_SIZE
-        elif owner_direction_label == LEFT_LABEL:
+            self.pos_y = owner_pos[1] + cfg.TILE_SIZE
+        elif owner_direction_label == cfg.LEFT_LABEL:
             self.direction_vector.x = -1
             self.direction_vector.y = 0
-            self.pos_x = owner_pos[0] - TILE_SIZE
+            self.pos_x = owner_pos[0] - cfg.TILE_SIZE
             self.pos_y = owner_pos[1]
 
         self.distance_travelled = 0
-        self.max_distance = TILE_SIZE
+        self.max_distance = cfg.TILE_SIZE
 
         self.move_animation_cooldown = 100
 
-        self.frame_id = FLAME_FRAME_ID
-        self.nb_frames = FLAME_FRAMES
+        self.frame_id = cfg.FLAME_FRAME_ID
+        self.nb_frames = cfg.FLAME_FRAMES
         self.load_animation_frames(tileset.PARTICLES_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -1044,10 +1044,10 @@ class Flame(Particle):
         self.hitbox = self.rect
 
         self.is_active = True
-        self.collision_damage = FLAME_DMG
-        self.speed = FLAME_SPEED
+        self.collision_damage = cfg.FLAME_DMG
+        self.speed = cfg.FLAME_SPEED
 
-        self.flame_sound = pygame.mixer.Sound(SOUND_FLAME)
+        self.flame_sound = pygame.mixer.Sound(cfg.SOUND_FLAME)
         self.flame_sound.set_volume(0.3)
         self.flame_sound.play()
 
@@ -1115,8 +1115,8 @@ class HeartReceptacle(Particle):
         self.level_id = level_id
         self.dropped_by_event = dropped_by_event
 
-        self.frame_id = HEARTRECEPTACLE_FRAME_ID
-        self.nb_frames = HEARTRECEPTACLE_FRAMES
+        self.frame_id = cfg.HEARTRECEPTACLE_FRAME_ID
+        self.nb_frames = cfg.HEARTRECEPTACLE_FRAMES
         self.load_animation_frames(tileset.CONSUMABLES_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -1148,10 +1148,10 @@ class HeartReceptacle(Particle):
     def effect(self):
         if self.dropped_by_event:
             level_id = str(game.Level().current_map) + str(game.Level().current_map_screen)
-            MONSTER_KILL_EVENT.pop(level_id)
+            cfg.MONSTER_KILL_EVENT.pop(level_id)
         else:
-            MAP_ITEMS[self.level_id][HEARTRECEPTACLE_LABEL] = False
-        game.Level().player_pick_up(HEARTRECEPTACLE_LABEL)
+            cfg.MAP_ITEMS[self.level_id][cfg.HEARTRECEPTACLE_LABEL] = False
+        game.Level().player_pick_up(cfg.HEARTRECEPTACLE_LABEL)
 
     def update(self):
         super().update()
@@ -1165,8 +1165,8 @@ class Ladder(Particle):
 
         self.level_id = level_id
 
-        self.frame_id = LADDER_FRAME_ID
-        self.nb_frames = LADDER_FRAMES
+        self.frame_id = cfg.LADDER_FRAME_ID
+        self.nb_frames = cfg.LADDER_FRAMES
         self.load_animation_frames(tileset.ITEMS_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -1196,8 +1196,8 @@ class Ladder(Particle):
         pass
 
     def effect(self):
-        MAP_ITEMS[self.level_id][LADDER_LABEL] = False
-        game.Level().player_pick_up(LADDER_LABEL)
+        cfg.MAP_ITEMS[self.level_id][cfg.LADDER_LABEL] = False
+        game.Level().player_pick_up(cfg.LADDER_LABEL)
 
     def update(self):
         super().update()
@@ -1211,8 +1211,8 @@ class RedCandle(Particle):
 
         self.level_id = level_id
 
-        self.frame_id = RED_CANDLE_FRAME_ID
-        self.nb_frames = RED_CANDLE_FRAMES
+        self.frame_id = cfg.RED_CANDLE_FRAME_ID
+        self.nb_frames = cfg.RED_CANDLE_FRAMES
         self.load_animation_frames(tileset.ITEMS_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -1242,8 +1242,8 @@ class RedCandle(Particle):
         pass
 
     def effect(self):
-        MAP_ITEMS[self.level_id][CANDLE_LABEL] = False
-        game.Level().player_pick_up(CANDLE_LABEL)
+        cfg.MAP_ITEMS[self.level_id][cfg.CANDLE_LABEL] = False
+        game.Level().player_pick_up(cfg.CANDLE_LABEL)
 
     def update(self):
         super().update()
@@ -1258,8 +1258,8 @@ class Boomerang(Particle):
         self.level_id = level_id
         self.dropped_by_event = dropped_by_event
 
-        self.frame_id = BOOMERANG_FRAME_ID
-        self.nb_frames = BOOMERANG_FRAMES
+        self.frame_id = cfg.BOOMERANG_FRAME_ID
+        self.nb_frames = cfg.BOOMERANG_FRAMES
         self.load_animation_frames(tileset.ITEMS_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -1290,10 +1290,10 @@ class Boomerang(Particle):
 
     def effect(self):
         if not self.dropped_by_event:
-            MAP_ITEMS[self.level_id][BOOMERANG_LABEL] = False
+            cfg.MAP_ITEMS[self.level_id][cfg.BOOMERANG_LABEL] = False
         else:
-            MONSTER_KILL_EVENT.pop(self.level_id)
-        game.Level().player_pick_up(BOOMERANG_LABEL)
+            cfg.MONSTER_KILL_EVENT.pop(self.level_id)
+        game.Level().player_pick_up(cfg.BOOMERANG_LABEL)
 
     def update(self):
         super().update()
@@ -1307,8 +1307,8 @@ class WoodenSword(Particle):
 
         self.level_id = level_id
 
-        self.frame_id = WOOD_SWORD_FRAME_ID
-        self.nb_frames = WOOD_SWORD_FRAMES
+        self.frame_id = cfg.WOOD_SWORD_FRAME_ID
+        self.nb_frames = cfg.WOOD_SWORD_FRAMES
         self.load_animation_frames(tileset.ITEMS_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -1338,8 +1338,8 @@ class WoodenSword(Particle):
         pass
 
     def effect(self):
-        MAP_ITEMS[self.level_id][WOOD_SWORD_LABEL] = False
-        game.Level().player_pick_up(WOOD_SWORD_LABEL)
+        cfg.MAP_ITEMS[self.level_id][cfg.WOOD_SWORD_LABEL] = False
+        game.Level().player_pick_up(cfg.WOOD_SWORD_LABEL)
 
     def update(self):
         super().update()
@@ -1353,8 +1353,8 @@ class Triforce(Particle):
 
         self.level_id = level_id
 
-        self.frame_id = TRIFORCE_FRAME_ID
-        self.nb_frames = TRIFORCE_FRAMES
+        self.frame_id = cfg.TRIFORCE_FRAME_ID
+        self.nb_frames = cfg.TRIFORCE_FRAMES
         self.load_animation_frames(tileset.ITEMS_TILE_SET)
 
         self.image = self.move_animations[0]
@@ -1384,7 +1384,7 @@ class Triforce(Particle):
         pass
 
     def effect(self):
-        MAP_ITEMS[self.level_id][TRIFORCE_FRAME_ID] = False
+        cfg.MAP_ITEMS[self.level_id][cfg.TRIFORCE_FRAME_ID] = False
         game.Level().pick_up_triforce()
 
     def update(self):

--- a/code/player.py
+++ b/code/player.py
@@ -846,6 +846,23 @@ class Player(Entity):
         self.isDead = False
         self.is_spinning = False
 
+    def reload_player(self):
+        if self.health <= PLAYER_HEALTH_PER_HEART:
+            self.low_health_sound.play(loops=-1)
+            self.is_low_health = True
+        else:
+            self.is_low_health = False
+            self.low_health_sound.stop()
+
+        self.is_boomerang_thrown = False
+        self.is_candle_lit = False
+        self.direction_label = DOWN_LABEL
+        self.state = STATE_IDLE
+        if self.ladder_in_use:
+            self.ladder_in_use = False
+            self.ladder.kill()
+            self.ladder = None
+
     def update(self):
         if not self.isDead:
             if STATE_HURT not in self.state:

--- a/code/settings.py
+++ b/code/settings.py
@@ -16,6 +16,7 @@ TEXT_OFFSET = TEXT_MARGIN * FONT_SPRITE_SIZE
 
 # CONSTANT STR
 #
+SAVE_FILE_PATH = "./save_file"
 NONE_LABEL = 'None'
 GAME_NAME = 'A Zelda NES homage in Python'
 VICTORY_TEXT = 'congratulations !\n\n\n\n\n\n\n\n\n\nthe kingdom is safe,\nand you\'re a winner !!!'
@@ -805,6 +806,7 @@ FLAME_2_POS = (NPC_X + 6 * TILE_SIZE, NPC_Y)
 
 # SHOPS AND SHOP CONTENT
 #
+# Warning : using ", " in the text of the shop will crash the game when the player loads their save file.
 SHOPS = {
     'sword_cave0': {ITEMS_LABEL: {WOOD_SWORD_LABEL: 0},
                     NPC_ID_LABEL: OLD_MAN_ID,
@@ -825,7 +827,7 @@ SHOPS = {
                           TEXT_LABEL: 'hey mister hero. you\'ll need this.'},
     'dungeon0_4': {ITEMS_LABEL: {BOMB_LABEL: 20},
                    NPC_ID_LABEL: MOBLIN_ID,
-                   TEXT_LABEL: 'bombs are shocking, as a heavy armored monster once told me.'}
+                   TEXT_LABEL: 'a heavy armored monster once told me that bombs are quite shocking.'}
 }
 # SHOP_dict name indicates the tile set
 # Key is label of item

--- a/code/support.py
+++ b/code/support.py
@@ -1,5 +1,7 @@
 import sys
 import pygame
+import re
+import settings as cfg
 from csv import reader
 
 
@@ -17,3 +19,140 @@ def import_csv_layout(path, ignore_non_existing_file=False):
             sys.exit()
 
     return layout
+
+
+def str_to_dict(str_in: str):
+    dictionary = {}
+    if str_in != "{}":
+        dict_entries = str_in[1:-1].split(', ')
+
+        for entry in dict_entries:
+            data = entry.split(': ', 1)
+            level_id = data[0][1:-1]
+            if data[1] == "True" or data[1] == "False":
+                dictionary[level_id] = eval(data[1])
+            else:
+                match_int = re.findall('-?[0-9]+', data[1])
+                if match_int and match_int[0] == data[1]:
+                    dictionary[level_id] = int(data[1])
+                else:
+                    dictionary[level_id] = data[1][1:-1]
+
+    return dictionary
+
+
+def shop_str_to_dict(str_in: str):
+    dictionary = {}
+    items_dict_regex = "({['a-zA-Z0-9 :,-]+})"
+    items_dict_str = re.findall(items_dict_regex, str_in)
+    dictionary[cfg.ITEMS_LABEL] = str_to_dict(items_dict_str[0])
+    str_in = str_in.replace('{\'' + cfg.ITEMS_LABEL + '\': ' + items_dict_str[0] + ', \'' + cfg.NPC_ID_LABEL
+                            + '\': ', '', 1)
+    npc_id = int(str_in.split(', ', 1)[0])
+    dictionary[cfg.NPC_ID_LABEL] = npc_id
+    str_in = str_in.replace(str(npc_id) + ', \'' + cfg.TEXT_LABEL + '\': ', '', 1)
+    text = str_in[1:-2]
+    text = text.replace('\\n', '\n')
+    dictionary[cfg.TEXT_LABEL] = text
+
+    return dictionary
+
+
+def load_from_save_file(player):
+    try:
+        with open(cfg.SAVE_FILE_PATH) as file:
+            save_data = file.read().splitlines()
+            player.current_max_health = int(save_data[0])
+            player.health = int(save_data[1])
+            player.bombs = int(save_data[2])
+            player.keys = int(save_data[3])
+            player.money = int(save_data[4])
+            player.has_boomerang = eval(save_data[5])
+            player.has_bombs = eval(save_data[6])
+            player.has_candle = eval(save_data[7])
+            player.has_ladder = eval(save_data[8])
+            player.has_wood_sword = eval(save_data[9])
+            player.itemA = str(save_data[10])
+            player.itemB = str(save_data[11])
+
+            secrets_revealed = save_data[12]
+            cfg.MAP_SECRETS_REVEALED.clear()
+            cfg.MAP_SECRETS_REVEALED = str_to_dict(secrets_revealed)
+
+            map_items = save_data[13][1:-1]
+            cfg.MAP_ITEMS.clear()
+            subdict_regex = "({'[a-zA-Z0-9 ]+': ((?:True)|(?:False))((, '[a-zA-Z0-9 ]+': ((?:True)|(?:False)))*)})"
+            sub_dicts = re.findall(subdict_regex, map_items)
+            for entry in sub_dicts:
+                key = map_items.split(': ' + entry[0])[0]
+                level_id = key[1:-1]
+                item_list = entry[0]
+                cfg.MAP_ITEMS[level_id] = str_to_dict(item_list)
+                map_items = map_items.replace(key + ': ', '', 1)
+                map_items = map_items.replace(entry[0], '', 1)
+                map_items = map_items.replace(', ', '', 1)
+
+            shop_list = save_data[14][1:-1]
+            cfg.SHOPS.clear()
+            subdict_regex = "('[a-zA-Z0-9_]+': {'(?:items)': {'[a-zA-Z0-9_ ]+': -*[0-9]+(, '[a-zA-Z0-9_ ]+': [0-9]+)*}, '(?:npc_id)': [0-9]+, '(?:text)': ('|\")[a-zA-z0-9\ ',!.?]+('|\")})"
+            sub_dicts = re.findall(subdict_regex, shop_list)
+            for entry in sub_dicts:
+                split_entry = entry[0].split(': ', 1)
+                key = split_entry[0]
+                level_id = key[1:-1]
+                shop_data = split_entry[1]
+                cfg.SHOPS[level_id] = shop_str_to_dict(shop_data)
+                shop_list = shop_list.replace(entry[0], '', 1)
+                shop_list = shop_list.replace(', ', '', 1)
+
+            monster_killed = save_data[15]
+            cfg.MONSTER_KILL_EVENT.clear()
+            cfg.MONSTER_KILL_EVENT = str_to_dict(monster_killed)
+
+            decimated_dungeons = save_data[16]
+            cfg.DUNGEON_DECIMATION.clear()
+            cfg.DUNGEON_DECIMATION = str_to_dict(decimated_dungeons)
+
+            doors = save_data[17][1:-1]
+            cfg.DUNGEON_DOORS.clear()
+            subdict_regex = "(({})|{'((?:right)|(?:left)|(?:up)|(?:down))': '[a-zA-Z ]+'(, '((?:right)|(?:left)|(?:up)(?:down))': '[a-zA-Z ]+')*})"
+            sub_dicts = re.findall(subdict_regex, doors)
+            for entry in sub_dicts:
+                key = doors.split(': ' + entry[0])[0]
+                level_id = key[1: -1]
+                door_list = entry[0]
+                cfg.DUNGEON_DOORS[level_id] = str_to_dict(door_list)
+                doors = doors.replace(key + ': ', '', 1)
+                doors = doors.replace(entry[0], '', 1)
+                doors = doors.replace(', ', '', 1)
+
+        file.close()
+    except OSError as error:
+        raise OSError(error)
+
+
+def save_to_file(player):
+    try:
+        with open(cfg.SAVE_FILE_PATH, "w") as file:
+            save_content = (f'{player.current_max_health}\n'
+                            + f'{player.health}\n'
+                            + f'{player.bombs}\n'
+                            + f'{player.keys}\n'
+                            + f'{player.money}\n'
+                            + f'{player.has_boomerang}\n'
+                            + f'{player.has_bombs}\n'
+                            + f'{player.has_candle}\n'
+                            + f'{player.has_ladder}\n'
+                            + f'{player.has_wood_sword}\n'
+                            + f'{player.itemA}\n'
+                            + f'{player.itemB}\n'
+                            + f'{cfg.MAP_SECRETS_REVEALED}\n'
+                            + f'{cfg.MAP_ITEMS}\n'
+                            + f'{cfg.SHOPS}\n'
+                            + f'{cfg.MONSTER_KILL_EVENT}\n'
+                            + f'{cfg.DUNGEON_DECIMATION}\n'
+                            + f'{cfg.DUNGEON_DOORS}\n')
+            file.write(save_content)
+            file.close()
+    except OSError as error:
+        raise OSError(error)

--- a/code/warp.py
+++ b/code/warp.py
@@ -1,6 +1,6 @@
 import pygame
 import level as game
-from settings import *
+import settings as cfg
 
 
 class Warp(pygame.sprite.Sprite):
@@ -15,14 +15,14 @@ class Warp(pygame.sprite.Sprite):
         self.player_ref = player
         self.in_transition = False
 
-        self.image = pygame.Surface((TILE_SIZE, TILE_SIZE))
+        self.image = pygame.Surface((cfg.TILE_SIZE, cfg.TILE_SIZE))
         self.rect = self.image.get_rect(topleft=pos)
         self.hitbox = self.rect.inflate(-4, -4)
 
     def collisions(self):
         player_hitbox_revised = self.player_ref.hitbox
         if self.warp_id < 4:
-            player_hitbox_revised = player_hitbox_revised.inflate(0, PLAYER_HITBOX_Y_DEFLATE)
+            player_hitbox_revised = player_hitbox_revised.inflate(0, cfg.PLAYER_HITBOX_Y_DEFLATE)
         player_hitbox_revised.center = self.player_ref.hitbox.center
         if not self.in_transition and player_hitbox_revised.colliderect(self.hitbox):
             self.in_transition = True
@@ -56,9 +56,9 @@ class SecretPassage(Warp):
 
     def reveal(self):
         self.is_revealed = True
-        MAP_SECRETS_REVEALED[self.level_id] = True
-        self.hitbox = self.rect.inflate(-TILE_SIZE, -TILE_SIZE)
-        if UNDERWORLD_STAIRS[int(self.warp_id) - 4][STAIRS_LABEL]:
+        cfg.MAP_SECRETS_REVEALED[self.level_id] = True
+        self.hitbox = self.rect.inflate(-cfg.TILE_SIZE, -cfg.TILE_SIZE)
+        if cfg.UNDERWORLD_STAIRS[int(self.warp_id) - 4][cfg.STAIRS_LABEL]:
             self.hitbox.top = self.rect.top
         for obstacle in self.obstacle_sprites:
             if obstacle.rect.colliderect(self.rect):


### PR DESCRIPTION
Player can now save their game state by pressing SAVE_KEY (F5), or restoring their save game state by pressing LOAD_KEY (F6)

A message appears on screen to inform on success, unavailability of the feature, or failure of command.

Saving registers all progress made (health, max health, money, keys, bombs, items picked up, revealed secrets, shop inventories, cleaned dungeon rooms, dungeon doors states, dungeon monsters killed events, equipped items)
Loading these values allow to continue the game with the progress from the save file, and resets the current level screen and player position to the default starting position.

Screens where all monsters were killed but were not in dungeon are not anymore registered in MONSTER_KILL_EVENT (it was never used, so no change visible from the player's point of view)

Huge refacto of how settings.py 's "global" values are accessed in many files, to allow proper modification through loading of the different dictionnaries that register some of the player's progress.